### PR TITLE
Fix emoji appearance with higher font size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.5
+
+* Fix appearance of emoji when device font size is not default 🖥
+
 ## 1.0.4
 
 * Make Emoji class accessible 🙌

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -21,7 +21,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.0.4"
+    version: "1.0.5"
   ffi:
     dependency: transitive
     description:

--- a/lib/src/default_emoji_picker_view.dart
+++ b/lib/src/default_emoji_picker_view.dart
@@ -123,6 +123,7 @@ class _DefaultEmojiPickerViewState extends State<DefaultEmojiPickerView>
                     },
                     child: Center(
                       child: Text(item.emoji,
+                          textScaleFactor: 1,
                           style: TextStyle(fontSize: emojiSize)),
                     )),
               ))

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: emoji_picker_flutter
 description: A Flutter package that provides an Emoji picker widget with 1500+ emojis in 8 categories.
-version: 1.0.4
+version: 1.0.5
 homepage: https://github.com/Fintasys/emoji_picker_flutter
 
 environment:


### PR DESCRIPTION
Related issue #11 

When user changes display or font settings on the device it can happen that the emojis are cut off. 
To prevent this we need to keep the scale ratio.