### PR TITLE
[BugFix] Avoid multiple rebuilds of emojis categories

### DIFF
--- a/lib/src/emoji_picker.dart
+++ b/lib/src/emoji_picker.dart
@@ -104,15 +104,23 @@ class _EmojiPickerState extends State<EmojiPicker> {
 
   List<CategoryEmoji> categoryEmoji = List.empty(growable: true);
   List<RecentEmoji> recentEmoji = List.empty(growable: true);
+  late Future<void> updateEmojiFuture;
 
   // Prevent emojis to be reloaded with every build
   bool loaded = false;
+
+  @override
+  void initState() {
+    super.initState();
+    updateEmojiFuture = _updateEmojis();
+  }
 
   @override
   void didUpdateWidget(covariant EmojiPicker oldWidget) {
     if (oldWidget.config != widget.config) {
       // Config changed - rebuild EmojiPickerView completely
       loaded = false;
+      updateEmojiFuture = _updateEmojis();
     }
     super.didUpdateWidget(oldWidget);
   }
@@ -121,7 +129,7 @@ class _EmojiPickerState extends State<EmojiPicker> {
   Widget build(BuildContext context) {
     if (!loaded) {
       // Load emojis
-      _updateEmojis().then(
+      updateEmojiFuture.then(
         (value) => WidgetsBinding.instance!.addPostFrameCallback((_) {
           if (!mounted) return;
           setState(() {


### PR DESCRIPTION
Another attempt to fix #12 

Theory is that `build` is called at least twice before `loaded` is set to true.  
This could lead to the situation that both futures have cleared the list and start adding items to the list in parallel.
Extracting `_updateEmoji` to variable will avoid that the Future will be created multiple times and should fix the issue.