### PR TITLE
Do not call setState when widget is not mounted

### DIFF
--- a/lib/src/emoji_picker.dart
+++ b/lib/src/emoji_picker.dart
@@ -121,10 +121,15 @@ class _EmojiPickerState extends State<EmojiPicker> {
   Widget build(BuildContext context) {
     if (!loaded) {
       // Load emojis
-      _updateEmojis().then((value) =>
-          WidgetsBinding.instance!.addPostFrameCallback((_) => setState(() {
-                loaded = true;
-              })));
+      _updateEmojis().then(
+        (value) => WidgetsBinding.instance!.addPostFrameCallback((_) {
+          if (mounted) {
+            setState(() {
+              loaded = true;
+            });
+          }
+        }),
+      );
 
       // Show loading indicator
       return const Center(child: CircularProgressIndicator());
@@ -151,10 +156,12 @@ class _EmojiPickerState extends State<EmojiPicker> {
       if (widget.config.showRecentsTab) {
         _addEmojiToRecentlyUsed(emoji).then((value) {
           if (category != Category.RECENT) {
-            setState(() {
-              // rebuild to update recent emoji tab
-              // when it is not current tab
-            });
+            if (mounted) {
+              setState(() {
+                // rebuild to update recent emoji tab
+                // when it is not current tab
+              });
+            }
           }
         });
       }

--- a/lib/src/emoji_picker.dart
+++ b/lib/src/emoji_picker.dart
@@ -123,11 +123,10 @@ class _EmojiPickerState extends State<EmojiPicker> {
       // Load emojis
       _updateEmojis().then(
         (value) => WidgetsBinding.instance!.addPostFrameCallback((_) {
-          if (mounted) {
-            setState(() {
-              loaded = true;
-            });
-          }
+          if (!mounted) return;
+          setState(() {
+            loaded = true;
+          });
         }),
       );
 
@@ -155,13 +154,11 @@ class _EmojiPickerState extends State<EmojiPicker> {
     return (category, emoji) {
       if (widget.config.showRecentsTab) {
         _addEmojiToRecentlyUsed(emoji).then((value) {
-          if (category != Category.RECENT) {
-            if (mounted) {
-              setState(() {
-                // rebuild to update recent emoji tab
-                // when it is not current tab
-              });
-            }
+          if (category != Category.RECENT && mounted) {
+            setState(() {
+              // rebuild to update recent emoji tab
+              // when it is not current tab
+            });
           }
         });
       }


### PR DESCRIPTION
This fixes the error if we try to call `setState` when the widget is not mounted:

```
════════ Exception caught by scheduler library ═════════════════════════════════
The following assertion was thrown during a scheduler callback:
setState() called after dispose(): _EmojiPickerState#e6e7c(lifecycle state: defunct, not mounted)

This error happens if you call setState() on a State object for a widget that no longer appears in the widget tree (e.g., whose parent widget no longer includes the widget in its build). This error can occur when code calls setState() from a timer or an animation callback.

The preferred solution is to cancel the timer or stop listening to the animation in the dispose() callback. Another solution is to check the "mounted" property of this object before calling setState() to ensure the object is still in the tree.
This error might indicate a memory leak if setState() is being called because another object is retaining a reference to this State object after it has been removed from the tree. To avoid memory leaks, consider breaking the reference to this object during dispose().

When the exception was thrown, this was the stack
#0      State.setState.<anonymous closure> package:flutter/…/widgets/framework.dart:1052
#1      State.setState package:flutter/…/widgets/framework.dart:1087
#2      _EmojiPickerState.build.<anonymous closure>.<anonymous closure> package:emoji_picker_flutter/src/emoji_picker.dart:125
#3      SchedulerBinding._invokeFrameCallback package:flutter/…/scheduler/binding.dart:1143
#4      SchedulerBinding.handleDrawFrame package:flutter/…/scheduler/binding.dart:1088
#5      SchedulerBinding._handleDrawFrame package:flutter/…/scheduler/binding.dart:996
#9      _invoke (dart:ui/hooks.dart:166:10)
#10     PlatformDispatcher._drawFrame (dart:ui/platform_dispatcher.dart:270:5)
#11     _drawFrame (dart:ui/hooks.dart:129:31)
```