### PR TITLE
[BugFix] Avoid rebuilds on every setState() when custom config is given

### DIFF
--- a/lib/src/config.dart
+++ b/lib/src/config.dart
@@ -115,4 +115,48 @@ class Config {
         throw Exception('Unsupported Category');
     }
   }
+
+  @override
+  bool operator ==(other) {
+    return (other is Config) &&
+        other.columns == columns &&
+        other.emojiSizeMax == emojiSizeMax &&
+        other.verticalSpacing == verticalSpacing &&
+        other.horizontalSpacing == horizontalSpacing &&
+        other.initCategory == initCategory &&
+        other.bgColor == bgColor &&
+        other.indicatorColor == indicatorColor &&
+        other.iconColor == iconColor &&
+        other.iconColorSelected == iconColorSelected &&
+        other.progressIndicatorColor == progressIndicatorColor &&
+        other.backspaceColor == backspaceColor &&
+        other.showRecentsTab == showRecentsTab &&
+        other.recentsLimit == recentsLimit &&
+        other.noRecentsText == noRecentsText &&
+        other.noRecentsStyle == noRecentsStyle &&
+        other.tabIndicatorAnimDuration == tabIndicatorAnimDuration &&
+        other.categoryIcons == categoryIcons &&
+        other.buttonMode == buttonMode;
+  }
+
+  @override
+  int get hashCode =>
+      columns.hashCode ^
+      emojiSizeMax.hashCode ^
+      verticalSpacing.hashCode ^
+      horizontalSpacing.hashCode ^
+      initCategory.hashCode ^
+      bgColor.hashCode ^
+      indicatorColor.hashCode ^
+      iconColor.hashCode ^
+      iconColorSelected.hashCode ^
+      progressIndicatorColor.hashCode ^
+      backspaceColor.hashCode ^
+      showRecentsTab.hashCode ^
+      recentsLimit.hashCode ^
+      noRecentsText.hashCode ^
+      noRecentsStyle.hashCode ^
+      tabIndicatorAnimDuration.hashCode ^
+      categoryIcons.hashCode ^
+      buttonMode.hashCode;
 }


### PR DESCRIPTION
Attempt to fix #27

Check this line: https://github.com/Fintasys/emoji_picker_flutter/blob/master/lib/src/emoji_picker.dart#L113

Here, `oldWidget.config != widget.config` will always true even they have same values inside as it is not comparing the instance member values of 2 objects. That's why the rebuild happens on every setState() if we provide a Config() object for customization.

So I have Overridden the == operator in the Config class to compare if 2 objects are the same or not according to their values. The hashCode property is also overridden to maintain consistency.