### PR TITLE
Feature: Emoji-List Versioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 1.1.0
 * New feature: EmojiPickerUtils provide access to recent emojis, search emoji and adding emoji to recently-used list
 * New feature: Skin-Tone Support
+* New feature: Emoji-List Versioning (force update users cached emoji's if necessary between versions)
 
 ## 1.0.8
 

--- a/lib/src/emoji_lists.dart
+++ b/lib/src/emoji_lists.dart
@@ -1,6 +1,9 @@
 // Copyright information
 // File originally from https://github.com/JeffG05/emoji_picker
 
+/// Emoji Version
+const int version = 1;
+
 /// Map of all possible emojis along with their names in [Category.SMILEYS]
 final Map<String, String> smileys = Map.fromIterables([
   'Grinning Face',

--- a/lib/src/emoji_picker.dart
+++ b/lib/src/emoji_picker.dart
@@ -234,6 +234,9 @@ class EmojiPickerState extends State<EmojiPicker> {
             }).toList()),
       );
     });
+
+    // Update emoji list version once all categories were cached
+    _emojiPickerInternalUtils.updateEmojiVersion();
   }
 
   // Set [hasSkinTone] to true for emoji that support skin tones

--- a/lib/src/emoji_picker_internal_utils.dart
+++ b/lib/src/emoji_picker_internal_utils.dart
@@ -19,7 +19,8 @@ class EmojiPickerInternalUtils {
   Future<bool> isEmojiUpdateAvailable() async {
     final prefs = await SharedPreferences.getInstance();
     var emojiVersion = prefs.getInt(_emojiVersion) ?? 0;
-    return emoji_list.version > emojiVersion;
+    // != to support downgrading of emoji_picker versions
+    return emoji_list.version != emojiVersion;
   }
 
   /// Updates local emoji version with current version

--- a/test/emoji_picker_flutter_test.dart
+++ b/test/emoji_picker_flutter_test.dart
@@ -1,10 +1,13 @@
 import 'package:emoji_picker_flutter/emoji_picker_flutter.dart';
+import 'package:emoji_picker_flutter/src/emoji_lists.dart' as emoji_list;
 import 'package:emoji_picker_flutter/src/emoji_picker_internal_utils.dart';
 import 'package:emoji_picker_flutter/src/emoji_skin_tones.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import 'package:test/test.dart';
 
 void main() {
   skinToneTests();
+  emojiVersioningTests();
 }
 
 void skinToneTests() {
@@ -38,5 +41,29 @@ void skinToneTests() {
     expect(utils.removeSkinTone(const Emoji('', '👍🏻')).emoji, '👍');
     expect(utils.removeSkinTone(const Emoji('', '🏊🏾‍♂️')).emoji, '🏊‍♂️');
     expect(utils.removeSkinTone(const Emoji('', '👱🏿‍♀️')).emoji, '👱‍♀️');
+  });
+}
+
+void emojiVersioningTests() {
+  test('isEmojiUpdateAvailable() no pre data', () async {
+    SharedPreferences.setMockInitialValues({});
+    final utils = EmojiPickerInternalUtils();
+    expect((await utils.isEmojiUpdateAvailable()), true);
+  });
+
+  test('isEmojiUpdateAvailable() pre data and outdated', () async {
+    SharedPreferences.setMockInitialValues({
+      'emoji_version': 0,
+    });
+    final utils = EmojiPickerInternalUtils();
+    expect((await utils.isEmojiUpdateAvailable()), true);
+  });
+
+  test('isEmojiUpdateAvailable() pre data and up to date', () async {
+    SharedPreferences.setMockInitialValues({
+      'emoji_version': emoji_list.version,
+    });
+    final utils = EmojiPickerInternalUtils();
+    expect((await utils.isEmojiUpdateAvailable()), false);
   });
 }


### PR DESCRIPTION
Sometimes the emoji-list needs to be updated (replace, add, remove) and currently the cached emoji's on the users devices won't be updated in that case. With Emoji-List versioning we can ensure that the emoji's will be force-refreshed if the data is outdated between versions.

closes #41 