### PR TITLE
Improvement: 'Replace emoji on limit exceed' config parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,8 @@ See the [demo](https://github.com/Fintasys/emoji_picker_flutter/blob/master/exam
 | skinToneIndicatorColor     | Color of the small triangle next to multiple skin tone emoji                               | Colors.grey     |
 | enableSkinTones     | Enable feature to select a skin tone of certain emoji's                               | true     |
 | showRecentsTab     | Show extra tab with recently used emoji                                | true     |
-| recentsLimit     | Limit of recently used emoji that will be saved                                | 28     |
+| recentsLimit     | Limit of recently used emoji that will be saved                                | 28
+| replaceEmojiOnLimitExceed | Replace latest emoji on recents list on limit exceed | false
 | noRecents     |  A widget (usually [Text]) to be displayed if no recent emojis to display                                | Text('No Recents', style: TextStyle(fontSize: 20, color: Colors.black26), textAlign: TextAlign.center)     |
 | tabIndicatorAnimDuration     | Duration of tab indicator to animate to next category                                | Duration(milliseconds: 300)     |
 | categoryIcons     | Determines the icon to display for each Category. You can change icons by setting them in the constructor.                               | CategoryIcons()     |

--- a/lib/src/config.dart
+++ b/lib/src/config.dart
@@ -31,6 +31,7 @@ class Config {
       this.enableSkinTones = true,
       this.showRecentsTab = true,
       this.recentsLimit = 28,
+      this.replaceEmojiOnLimitExceed = false,
       this.noRecents = DefaultNoRecentsWidget,
       this.tabIndicatorAnimDuration = kTabScrollDuration,
       this.categoryIcons = const CategoryIcons(),
@@ -98,6 +99,9 @@ class Config {
   /// Change between Material and Cupertino button style
   final ButtonMode buttonMode;
 
+  /// Replace latest emoji on recents list on limit exceed
+  final bool replaceEmojiOnLimitExceed;
+
   /// Get Emoji size based on properties and screen width
   double getEmojiSize(double width) {
     final maxSize = width / columns;
@@ -152,7 +156,8 @@ class Config {
         other.noRecents == noRecents &&
         other.tabIndicatorAnimDuration == tabIndicatorAnimDuration &&
         other.categoryIcons == categoryIcons &&
-        other.buttonMode == buttonMode;
+        other.buttonMode == buttonMode &&
+        other.replaceEmojiOnLimitExceed == replaceEmojiOnLimitExceed;
   }
 
   @override
@@ -176,5 +181,6 @@ class Config {
       noRecents.hashCode ^
       tabIndicatorAnimDuration.hashCode ^
       categoryIcons.hashCode ^
-      buttonMode.hashCode;
+      buttonMode.hashCode ^
+      replaceEmojiOnLimitExceed.hashCode;
 }

--- a/lib/src/emoji_picker_internal_utils.dart
+++ b/lib/src/emoji_picker_internal_utils.dart
@@ -150,6 +150,10 @@ class EmojiPickerInternalUtils {
       // Already exist in recent list
       // Just update counter
       recentEmoji[recentEmojiIndex].counter++;
+    } else if (recentEmoji.length == config.recentsLimit &&
+        config.replaceEmojiOnLimitExceed) {
+      // Replace latest emoji with fresh one
+      recentEmoji[recentEmoji.length - 1] = RecentEmoji(emoji, 1);
     } else {
       recentEmoji.add(RecentEmoji(emoji, 1));
     }


### PR DESCRIPTION
**With the current implementation, when recents limit exceed, even if new emojis (out of existing list)  selected multiple times, recents list will stay the same.** 

1. Added 'replaceEmojiOnLimitExceed' config parameter & implementation on picker internal utils
2. Added new parameter & description to README.md