### PR TITLE
Added the ability to put a key onto a custom widget

### DIFF
--- a/lib/src/emoji_picker_builder.dart
+++ b/lib/src/emoji_picker_builder.dart
@@ -6,7 +6,11 @@ import 'package:flutter/material.dart';
 /// Inhert this class to create your own EmojiPicker
 abstract class EmojiPickerBuilder extends StatefulWidget {
   /// Constructor
-  EmojiPickerBuilder(this.config, this.state);
+  EmojiPickerBuilder(
+    this.config,
+    this.state, {
+    Key? key,
+  }) : super(key: key);
 
   /// Config for customizations
   final Config config;


### PR DESCRIPTION
* Added an optional `Key` parameter to the `EmojiPickerBuilder` class. 

This was necessary to allow for stateful custom picker builders (e.g. when implementing search on a picker) 