### PR TITLE
Update example to support web implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ EmojiPicker(
     textEditingController: textEditionController, // pass here the same [TextEditingController] that is connected to your input field, usually a [TextFormField]
     config: Config(
         columns: 7,
-        emojiSizeMax: 32 * (Platform.isIOS ? 1.30 : 1.0), // Issue: https://github.com/flutter/flutter/issues/28894
+        emojiSizeMax: 32 * (defaultTargetPlatform == TargetPlatform.iOS ? 1.30 : 1.0), // Issue: https://github.com/flutter/flutter/issues/28894
         verticalSpacing: 0,
         horizontalSpacing: 0,
         gridPadding: EdgeInsets.zero,


### PR DESCRIPTION
For completion sake we can also add that the following is needed

```dart
import 'package:flutter/foundation.dart'
```