### PR TITLE
fix(android): build.gradle namespace

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -33,6 +33,8 @@ android {
     defaultConfig {
         minSdkVersion 16
     }
+
+    if (project.android.hasProperty("namespace")) { namespace 'com.fintasys.emoji_picker_flutter' }
 }
 
 dependencies {


### PR DESCRIPTION
Make it conditional, because it could break the build on Gradle < 8.0