### PR TITLE
Specify platform specific font family & fallback font families

### DIFF
--- a/lib/src/emoji_cell.dart
+++ b/lib/src/emoji_cell.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:emoji_picker_flutter/emoji_picker_flutter.dart';
 import 'package:emoji_picker_flutter/src/triangle_decoration.dart';
 import 'package:flutter/cupertino.dart';
@@ -99,16 +101,39 @@ class EmojiCell extends StatelessWidget {
     );
   }
 
+  static String? _getPlatformDefaultEmojiFont() {
+    if (Platform.isIOS || Platform.isMacOS) {
+      return 'Apple Color Emoji';
+    }
+    return null;
+  }
+
+  TextStyle _getEmojiTextStyle() {
+    final defaultStyle = TextStyle(
+      fontSize: emojiSize,
+      // If the user provided a style, don't override the font family.
+      fontFamily: textStyle == null ? _getPlatformDefaultEmojiFont() : null,
+      // Commonly available fallback fonts.
+      fontFamilyFallback: [
+        // iOS and MacOs.
+        'Apple Color Emoji',
+        // Android, ChromeOS, Ubuntu and some other Linux distros.
+        'NotoColorEmoji',
+        // Windows.
+        'Segoe UI Emoji',
+      ],
+      backgroundColor: Colors.transparent,
+      inherit: true,
+    );
+    return textStyle == null ? defaultStyle : textStyle!.merge(defaultStyle);
+  }
+
   /// Build and display Emoji centered of its parent
   Widget _buildEmoji() {
-    final style = TextStyle(
-      fontSize: emojiSize,
-      backgroundColor: Colors.transparent,
-    );
     final emojiText = Text(
       emoji.emoji,
       textScaleFactor: 1.0,
-      style: textStyle == null ? style : textStyle!.merge(style),
+      style: _getEmojiTextStyle(),
     );
 
     return Center(


### PR DESCRIPTION
This change helps resolve emoji rendering issues which have been reported by several different users across platforms. I filed two "canonical" issues for this problem, but others have been reported.

- On Android: https://github.com/Fintasys/emoji_picker_flutter/issues/171
- On iOS: https://github.com/Fintasys/emoji_picker_flutter/issues/170

This change helps address this problem by setting a default font family on iOS, MacOS, and Android. On iOS this is 'Apple Color Emoji', and on Android it is 'NotoColorEmoji'. We also specify several common fallback emoji font families which Flutter will use if the specified font family is unavailable. This is useful in case the user specifies an unavailable font family.

On iOS this actually resolves the rendering issue for U+2639, which you can see in the description of #170. Unfortunately this change does not seem to resolve the issue on Android when I tested it in the emulator, but it may help for some configurations of Android where Flutter can access the 'NotoColorEmoji' font.

FIXED=#170
BUG=#171,#163