### PR TITLE
Fix for auto scroll  issue

### DIFF
--- a/lib/src/emoji_picker.dart
+++ b/lib/src/emoji_picker.dart
@@ -113,6 +113,7 @@ class EmojiPicker extends StatefulWidget {
   const EmojiPicker({
     Key? key,
     this.textEditingController,
+    this.scrollController,
     this.onEmojiSelected,
     this.onBackspacePressed,
     this.config = const Config(),
@@ -126,6 +127,10 @@ class EmojiPicker extends StatefulWidget {
   /// [TextField] this widget handles inserting and deleting for you
   /// automatically.
   final TextEditingController? textEditingController;
+
+  /// If you provide the [ScrollController] that is linked to a
+  /// [TextField] this widget handles auto scrolling for you.
+  final ScrollController? scrollController;
 
   /// The function called when the emoji is selected
   final OnEmojiSelected? onEmojiSelected;
@@ -217,6 +222,12 @@ class EmojiPickerState extends State<EmojiPicker> {
       }
     }
 
+    if (widget.scrollController != null) {
+      final autoScrollController = widget.scrollController!;
+      autoScrollController
+          .jumpTo(autoScrollController.position.maxScrollExtent);
+    }
+
     widget.onBackspacePressed?.call();
   }
 
@@ -267,6 +278,12 @@ class EmojiPickerState extends State<EmojiPicker> {
             baseOffset: selection.start + emojiLength,
             extentOffset: selection.start + emojiLength,
           );
+      }
+
+      if (widget.scrollController != null) {
+        final autoScrollController = widget.scrollController!;
+        autoScrollController
+            .jumpTo(autoScrollController.position.maxScrollExtent);
       }
 
       widget.onEmojiSelected?.call(category, emoji);

--- a/lib/src/emoji_picker.dart
+++ b/lib/src/emoji_picker.dart
@@ -222,13 +222,9 @@ class EmojiPickerState extends State<EmojiPicker> {
       }
     }
 
-    if (widget.scrollController != null) {
-      final autoScrollController = widget.scrollController!;
-      autoScrollController
-          .jumpTo(autoScrollController.position.maxScrollExtent);
-    }
-
     widget.onBackspacePressed?.call();
+
+    _scrollToCursorAfterTextChange();
   }
 
   // Add recent emoji handling to tap listener
@@ -280,13 +276,9 @@ class EmojiPickerState extends State<EmojiPicker> {
           );
       }
 
-      if (widget.scrollController != null) {
-        final autoScrollController = widget.scrollController!;
-        autoScrollController
-            .jumpTo(autoScrollController.position.maxScrollExtent);
-      }
-
       widget.onEmojiSelected?.call(category, emoji);
+
+      _scrollToCursorAfterTextChange();
     };
   }
 
@@ -311,6 +303,19 @@ class EmojiPickerState extends State<EmojiPicker> {
     if (mounted) {
       setState(() {
         _loaded = true;
+      });
+    }
+  }
+
+  void _scrollToCursorAfterTextChange() {
+    if (widget.scrollController != null) {
+      final scrollController = widget.scrollController!;
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        scrollController.animateTo(
+          scrollController.position.maxScrollExtent,
+          duration: const Duration(milliseconds: 200),
+          curve: Curves.ease,
+        );
       });
     }
   }

--- a/lib/src/emoji_picker.dart
+++ b/lib/src/emoji_picker.dart
@@ -172,6 +172,7 @@ class EmojiPickerState extends State<EmojiPicker> {
   void initState() {
     super.initState();
     _updateEmojis();
+    widget.textEditingController?.addListener(_scrollToCursorAfterTextChange);
   }
 
   @override
@@ -224,7 +225,9 @@ class EmojiPickerState extends State<EmojiPicker> {
 
     widget.onBackspacePressed?.call();
 
-    _scrollToCursorAfterTextChange();
+    if (widget.textEditingController == null) {
+      _scrollToCursorAfterTextChange();
+    }
   }
 
   // Add recent emoji handling to tap listener
@@ -268,17 +271,20 @@ class EmojiPickerState extends State<EmojiPicker> {
         final newText =
             text.replaceRange(selection.start, selection.end, emoji.emoji);
         final emojiLength = emoji.emoji.length;
-        controller
-          ..text = newText
-          ..selection = selection.copyWith(
+        controller.value = controller.value.copyWith(
+          text: newText,
+          selection: selection.copyWith(
             baseOffset: selection.start + emojiLength,
             extentOffset: selection.start + emojiLength,
-          );
+          ),
+        );
       }
 
       widget.onEmojiSelected?.call(category, emoji);
 
-      _scrollToCursorAfterTextChange();
+      if (widget.textEditingController == null) {
+        _scrollToCursorAfterTextChange();
+      }
     };
   }
 


### PR DESCRIPTION
closes: https://github.com/Fintasys/emoji_picker_flutter/issues/179

## Usage Example:
Create a new ScrollController and pass it to TextField and EmojiPicker :

```
final scrollController = ScrollController();
...
TextField(
    minLines: 1,
    maxLines: 4, // Auto scrolling should work after 4th line
    focusNode: focusNode,
    controller: textEditingController,
    scrollController: scrollController,
    decoration: const InputDecoration(
        hintText: "Message",
        border: InputBorder.none,
    ),
),
...
EmojiPicker(
    textEditingController: textEditingController,
    scrollController: scrollController,
    onBackspacePressed: () {},
    ....
    ),
),
```

Reference: https://stackoverflow.com/questions/71408717/flutter-textfield-content-does-not-scroll-automatically-when-inserting-text