### PR TITLE
revert kotlin version back to 1.7.10

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,7 +2,7 @@ group 'com.fintasys.emoji_picker_flutter'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.9.22'
+    ext.kotlin_version = '1.7.10'
     repositories {
         google()
         mavenCentral()


### PR DESCRIPTION
kotlin version 1.9.22 compiles code with Java 17 and we're getting java 8 / 17 warnings from gradle 7.  Those warnings are errors in gradle 8. 

Latest stable flutter and it's packages are using 1.7.10.