### PR TITLE
Address Inconsistent JVM-target compatibility.

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -27,6 +27,15 @@ apply plugin: 'kotlin-android'
 android {
     compileSdkVersion 34
 
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
+    kotlinOptions {
+        jvmTarget = '1.8'
+    }
+
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
     }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,6 +25,8 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
+    namespace 'com.fintasys.emoji_picker_flutter'
+
     compileSdkVersion 34
 
     compileOptions {

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -28,6 +28,15 @@ apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 android {
     compileSdkVersion 34
 
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
+    kotlinOptions {
+        jvmTarget = '1.8'
+    }
+
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
     }


### PR DESCRIPTION
Fixes the following error: `Execution failed for task ':emoji_picker_flutter:compileReleaseKotlin'  Inconsistent JVM-target compatibility detected for tasks 'compileReleaseJavaWithJavac' (1.8) and 'compileReleaseKotlin' (17).`

Namespace specified for compatibility with newer Gradle versions.