### PR TITLE
Android: Fix build.gradle causes compile error

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,7 +2,6 @@ group 'com.fintasys.emoji_picker_flutter'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.9.22'
     repositories {
         google()
         mavenCentral()
@@ -10,7 +9,6 @@ buildscript {
 
     dependencies {
         classpath 'com.android.tools.build:gradle:4.1.0'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -46,6 +46,4 @@ android {
     }
 }
 
-dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-}
+dependencies {}


### PR DESCRIPTION
```Class 'kotlin.Unit' was compiled with an incompatible version of Kotlin. The binary version of its metadata is 1.9.0, expected version is 1.7.1.```