### PR TITLE
Search with the emoji itself too

### DIFF
--- a/lib/src/emoji_picker_utils.dart
+++ b/lib/src/emoji_picker_utils.dart
@@ -50,8 +50,9 @@ class EmojiPickerUtils {
 
     return _allAvailableEmojiEntities
         .toSet()
-        .where(
-            (emoji) => emoji.name.toLowerCase().contains(keyword.toLowerCase()))
+        .where((emoji) =>
+            (emoji.name.toLowerCase().contains(keyword.toLowerCase()) ||
+                emoji.emoji == keyword.trim()))
         .toSet()
         .toList();
   }


### PR DESCRIPTION
Before: Typing the emoji itself doesn't show the emoji as a search result
- Example:
  -  <img src=https://github.com/Fintasys/emoji_picker_flutter/assets/60294318/ada07d83-70e6-4ea1-9bba-86c33a558232 alt="Screenshot_20240625-231505" width=200 /> <img src=https://github.com/Fintasys/emoji_picker_flutter/assets/60294318/155dd610-2623-4664-8b90-db984c051559 alt="Screenshot_20240625-232204" width=200 />
- Typing "👋" won't give "👋" as an option -> not the best user experience

Solution that I'm proposing: modify the search logic a bit to find the emoji that matches exactly
- One problem of my code: It works well for most of the emojis, but there are two or three emojis that doesn't work (❤️ "red heart" is a big one)
