### PR TITLE
refactor(io): replace universal_io with internal lightweight solution

### DIFF
--- a/lib/src/core/io/io_helper.dart
+++ b/lib/src/core/io/io_helper.dart
@@ -1,0 +1,1 @@
+export 'io_web.dart' if (dart.library.io) 'dart:io';

--- a/lib/src/core/io/io_web.dart
+++ b/lib/src/core/io/io_web.dart
@@ -1,0 +1,64 @@
+import 'package:web/web.dart' as web;
+
+/// Information about the environment in which the current program is running.
+///
+/// Platform provides information such as the operating system,
+/// the hostname of the computer, the value of environment variables,
+/// the path to the running program,
+/// and other global properties of the program being run.
+class Platform {
+  /// Whether the operating system is a version of
+  /// [Linux](https://en.wikipedia.org/wiki/Linux).
+  ///
+  /// This value is `false` if the operating system is a specialized
+  /// version of Linux that identifies itself by a different name,
+  /// for example Android (see [isAndroid]).
+  static final bool isLinux = (operatingSystem == 'linux');
+
+  /// Whether the operating system is a version of
+  /// [macOS](https://en.wikipedia.org/wiki/MacOS).
+  static final bool isMacOS = (operatingSystem == 'macos');
+
+  /// Whether the operating system is a version of
+  /// [Microsoft Windows](https://en.wikipedia.org/wiki/Microsoft_Windows).
+  static final bool isWindows = (operatingSystem == 'windows');
+
+  /// Whether the operating system is a version of
+  /// [Android](https://en.wikipedia.org/wiki/Android_%28operating_system%29).
+  static final bool isAndroid = (operatingSystem == 'android');
+
+  /// Whether the operating system is a version of
+  /// [iOS](https://en.wikipedia.org/wiki/IOS).
+  static final bool isIOS = (operatingSystem == 'ios');
+
+  /// Whether the operating system is a version of
+  /// [Fuchsia](https://en.wikipedia.org/wiki/Google_Fuchsia).
+  static final bool isFuchsia = (operatingSystem == 'fuchsia');
+
+  /// A string representing the operating system or platform.
+  static String get operatingSystem {
+    final s = web.window.navigator.userAgent.toLowerCase();
+    if (s.contains('iphone') ||
+        s.contains('ipad') ||
+        s.contains('ipod') ||
+        s.contains('watch os')) {
+      return 'ios';
+    }
+    if (s.contains('mac os')) {
+      return 'macos';
+    }
+    if (s.contains('fuchsia')) {
+      return 'fuchsia';
+    }
+    if (s.contains('android')) {
+      return 'android';
+    }
+    if (s.contains('linux') || s.contains('cros') || s.contains('chromebook')) {
+      return 'linux';
+    }
+    if (s.contains('windows')) {
+      return 'windows';
+    }
+    return '';
+  }
+}

--- a/lib/src/emoji_picker.dart
+++ b/lib/src/emoji_picker.dart
@@ -3,7 +3,8 @@ import 'package:emoji_picker_flutter/locales/default_emoji_set_locale.dart';
 import 'package:emoji_picker_flutter/src/emoji_picker_internal_utils.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:universal_io/io.dart';
+
+import 'core/io/io_helper.dart';
 
 /// All the possible categories that [Emoji] can be put into
 ///

--- a/lib/src/emoji_picker_internal_utils.dart
+++ b/lib/src/emoji_picker_internal_utils.dart
@@ -5,7 +5,8 @@ import 'package:emoji_picker_flutter/emoji_picker_flutter.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:shared_preferences/shared_preferences.dart';
-import 'package:universal_io/io.dart';
+
+import 'core/io/io_helper.dart';
 
 /// Initial value for RecentEmoji
 const initVal = 1;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,6 @@ dependencies:
   plugin_platform_interface: ^2.1.8
   shared_preferences: ^2.3.3
   web: ^1.1.0
-  universal_io: ^2.2.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Description  
This PR removes the dependency on `universal_io` and replaces it with an internal, lightweight implementation. This change helps reduce external dependencies while maintaining the same functionality.  

Additionally, this update resolves the **WASM compatibility warning** on [pub.dev](https://pub.dev/packages/emoji_picker_flutter/score).  
I encountered the same warning in my package, [pro_image_editor](https://pub.dev/packages/pro_image_editor), indicating that it is not WASM-compatible. This issue arises because my package depends on yours, which in turn depends on `universal_io`.


## Changes  
- Added `io_helper.dart` and `io_web.dart` to handle platform-specific I/O operations.  
- Updated `emoji_picker.dart` and `emoji_picker_internal_utils.dart` to use the new internal I/O solution.  
- Modified `pubspec.yaml` to remove `universal_io`.  
- Ensured web builds correctly use `io_web.dart`, fixing the **wasm compatibility** issue.  

## Why this change?  
- Reduces external dependencies.  
- Provides a more lightweight and maintainable internal solution.  
- **Fixes the wasm compatibility warning** on [pub.dev](https://pub.dev/packages/emoji_picker_flutter/score).  

## Testing  
- [x]  Verified that all existing functionality remains intact.  
- [x] Tested on relevant platforms, including web, to ensure compatibility.  

## Checklist  
- [x] Code changes do not introduce breaking changes.  
- [x] Tested on different platforms, including web.  
- [x] Documentation/comments updated if necessary.  


---

Btw, thanks for creating this amazing package, it's really a **Flutter gem**!
