### PR TITLE
Recent emojis state update improvement

### DIFF
--- a/lib/emoji_picker_flutter.dart
+++ b/lib/emoji_picker_flutter.dart
@@ -12,6 +12,7 @@ export 'package:emoji_picker_flutter/src/category_view/category_view.dart';
 export 'package:emoji_picker_flutter/src/category_view/category_view_config.dart';
 export 'package:emoji_picker_flutter/src/category_view/default_category_tab_bar.dart';
 export 'package:emoji_picker_flutter/src/category_view/default_category_view.dart';
+export 'package:emoji_picker_flutter/src/category_view/recent_emojis_state_update_policy.dart';
 export 'package:emoji_picker_flutter/src/category_view/recent_tab_behavior.dart';
 export 'package:emoji_picker_flutter/src/config.dart';
 export 'package:emoji_picker_flutter/src/default_emoji_set.dart';

--- a/lib/src/category_view/category_view_config.dart
+++ b/lib/src/category_view/category_view_config.dart
@@ -26,6 +26,7 @@ class CategoryViewConfig {
     this.dividerColor,
     this.categoryIcons = const CategoryIcons(),
     this.customCategoryView,
+    this.recentEmojisUpdatePolicy = RecentEmojisStateUpdatePolicy.always,
   });
 
   /// Tab bar height
@@ -69,6 +70,14 @@ class CategoryViewConfig {
   /// Hot reload is not supported
   final CategoryViewBuilder? customCategoryView;
 
+  /// Determines the behavior of recent emojis list update in the state.
+  /// It can be configured to prevent recent emojis list from jumping when
+  /// user selects and emoji.
+  /// Defaults to always update recent emojis list.
+  /// NOTE: This affects only the widget state changes. Locally stored recent
+  /// emojis list is getting updated regardless of this setting.
+  final RecentEmojisStateUpdatePolicy recentEmojisUpdatePolicy;
+
   @override
   bool operator ==(other) {
     return (other is CategoryViewConfig) &&
@@ -83,7 +92,8 @@ class CategoryViewConfig {
         other.iconColorSelected == iconColorSelected &&
         other.backspaceColor == backspaceColor &&
         other.dividerColor == dividerColor &&
-        other.categoryIcons == categoryIcons;
+        other.categoryIcons == categoryIcons &&
+        other.recentEmojisUpdatePolicy == recentEmojisUpdatePolicy;
   }
 
   @override
@@ -99,5 +109,6 @@ class CategoryViewConfig {
       iconColorSelected.hashCode ^
       backspaceColor.hashCode ^
       dividerColor.hashCode ^
-      categoryIcons.hashCode;
+      categoryIcons.hashCode ^
+      recentEmojisUpdatePolicy.hashCode;
 }

--- a/lib/src/category_view/category_view_config.dart
+++ b/lib/src/category_view/category_view_config.dart
@@ -26,7 +26,7 @@ class CategoryViewConfig {
     this.dividerColor,
     this.categoryIcons = const CategoryIcons(),
     this.customCategoryView,
-    this.recentEmojisUpdatePolicy = RecentEmojisStateUpdatePolicy.always,
+    this.recentEmojisUpdatePolicy = RecentEmojisStateUpdatePolicy.notFromRecent,
   });
 
   /// Tab bar height
@@ -73,7 +73,7 @@ class CategoryViewConfig {
   /// Determines the behavior of recent emojis list update in the state.
   /// It can be configured to prevent recent emojis list from jumping when
   /// user selects and emoji.
-  /// Defaults to always update recent emojis list.
+  /// Defaults [RecentEmojisStateUpdatePolicy.notFromRecent].
   /// NOTE: This affects only the widget state changes. Locally stored recent
   /// emojis list is getting updated regardless of this setting.
   final RecentEmojisStateUpdatePolicy recentEmojisUpdatePolicy;

--- a/lib/src/category_view/recent_emojis_state_update_policy.dart
+++ b/lib/src/category_view/recent_emojis_state_update_policy.dart
@@ -1,0 +1,20 @@
+/// Enum for defining the state update policy for recent emojis.
+enum RecentEmojisStateUpdatePolicy {
+  /// No state updates.
+  never,
+
+  /// State updates only when selected emoji is not from the recent list.
+  notFromRecent,
+
+  /// State updates on every emoji selection.
+  always;
+
+  /// Returns true if the policy is [never].
+  bool get isNever => this == never;
+
+  /// Returns true if the policy is [notFromRecent].
+  bool get isNotFromRecent => this == notFromRecent;
+
+  /// Returns true if the policy is [always].
+  bool get isAlways => this == always;
+}

--- a/lib/src/emoji_picker_utils.dart
+++ b/lib/src/emoji_picker_utils.dart
@@ -176,7 +176,7 @@ class EmojiPickerUtils {
       {required GlobalKey<EmojiPickerState> key}) async {
     return await EmojiPickerInternalUtils()
         .clearRecentEmojisInLocalStorage()
-        .then((_) => key.currentState?.updateRecentEmoji([], refresh: true));
+        .then((_) => key.currentState?.updateRecentEmoji([]));
   }
 
   /// Returns the emoji regex


### PR DESCRIPTION
**This improvement gives more control over recent emojis list updates in widget's state.**

Now user can set `recentEmojisUpdatePolicy` parameter in `CategoryViewConfig` to define whether recent emojis list in the widget's state should update:
- `never` - never updates the list for `Recent` tab
- `notFromRecent` - updates the list only when selected emoji is NOT from `Recent` category
- `always` - always updates the list.

I added this improvement because even though there was a logic to skip `setState()` calls when selected emoji is from `Recent` category, my widget's `build()` can sometimes be triggered from the parent widget. This was leading to strange behaviour.

> **NOTE: Removed old logic that was updating the emojis list state, but was not calling `setState()` if the selected emoji was from `Recent` category. Now whole `updateRecentEmoji()` is getting called based on `recentEmojisUpdatePolicy`.**