### PR TITLE
fix(emoji-size): prevent emoji from being cut off by using FittedBox

### DIFF
--- a/example/lib/main_whatsapp.dart
+++ b/example/lib/main_whatsapp.dart
@@ -407,8 +407,7 @@ class WhatsAppSearchViewState extends SearchViewState {
   @override
   Widget build(BuildContext context) {
     return LayoutBuilder(builder: (context, constraints) {
-      final emojiSize =
-          widget.config.emojiViewConfig.getEmojiSize(constraints.maxWidth);
+      final emojiSize = widget.config.emojiViewConfig.emojiSizeMax;
       final emojiBoxSize =
           widget.config.emojiViewConfig.getEmojiBoxSize(constraints.maxWidth);
       return Container(

--- a/lib/src/emoji_view/default_emoji_picker_view.dart
+++ b/lib/src/emoji_view/default_emoji_picker_view.dart
@@ -46,8 +46,7 @@ class _DefaultEmojiPickerViewState extends State<DefaultEmojiPickerView>
   Widget build(BuildContext context) {
     return LayoutBuilder(
       builder: (context, constraints) {
-        final emojiSize =
-            widget.config.emojiViewConfig.getEmojiSize(constraints.maxWidth);
+        final emojiSize = widget.config.emojiViewConfig.emojiSizeMax;
         final emojiBoxSize =
             widget.config.emojiViewConfig.getEmojiBoxSize(constraints.maxWidth);
         return EmojiContainer(

--- a/lib/src/emoji_view/emoji_view_config.dart
+++ b/lib/src/emoji_view/emoji_view_config.dart
@@ -1,5 +1,3 @@
-import 'dart:math';
-
 import 'package:emoji_picker_flutter/emoji_picker_flutter.dart';
 import 'package:flutter/material.dart';
 
@@ -69,12 +67,6 @@ class EmojiViewConfig {
 
   /// Replace latest emoji on recents list on limit exceed
   final bool replaceEmojiOnLimitExceed;
-
-  /// Get Emoji size based on properties and screen width
-  double getEmojiSize(double width) {
-    final maxSize = width / columns;
-    return min(maxSize, emojiSizeMax);
-  }
 
   /// Get Emoji hitbox size based on properties and screen width
   double getEmojiBoxSize(double width) {

--- a/lib/src/search_view/default_search_view.dart
+++ b/lib/src/search_view/default_search_view.dart
@@ -16,8 +16,7 @@ class DefaultSearchViewState extends SearchViewState {
   @override
   Widget build(BuildContext context) {
     return LayoutBuilder(builder: (context, constraints) {
-      final emojiSize =
-          widget.config.emojiViewConfig.getEmojiSize(constraints.maxWidth);
+      final emojiSize = widget.config.emojiViewConfig.emojiSizeMax;
       final emojiBoxSize =
           widget.config.emojiViewConfig.getEmojiBoxSize(constraints.maxWidth);
 

--- a/lib/src/widgets/emoji_cell.dart
+++ b/lib/src/widgets/emoji_cell.dart
@@ -136,10 +136,12 @@ class EmojiCell extends StatelessWidget {
 
   /// Build and display Emoji centered of its parent
   Widget _buildEmoji() {
-    final emojiText = Text(
-      emoji.emoji,
-      textScaler: const TextScaler.linear(1.0),
-      style: _getEmojiTextStyle(),
+    final emojiText = FittedBox(
+      child: Text(
+        emoji.emoji,
+        textScaler: const TextScaler.linear(1.0),
+        style: _getEmojiTextStyle(),
+      ),
     );
 
     return emoji.hasSkinTone &&


### PR DESCRIPTION
Emojis were getting cut off in some layouts due to their size. This update wraps them in a `FittedBox` to ensure they scale properly and stay visible.

**Change:**
- Wrap emoji widget with `FittedBox` to prevent overflow.

This should improve consistency in emoji display across the UI.

Closes #240