### PR TITLE
Optimize `filterUnsupported` and `getRecentEmojis` functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,6 @@
 .packages
 .metadata
 .pub/
-.idea/
 
 build/
 

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -194,10 +194,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   path:
     dependency: transitive
     description:
@@ -391,10 +391,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.7"
   typed_data:
     dependency: transitive
     description:

--- a/example/windows/flutter/CMakeLists.txt
+++ b/example/windows/flutter/CMakeLists.txt
@@ -10,6 +10,11 @@ include(${EPHEMERAL_DIR}/generated_config.cmake)
 # https://github.com/flutter/flutter/issues/57146.
 set(WRAPPER_ROOT "${EPHEMERAL_DIR}/cpp_client_wrapper")
 
+# Set fallback configurations for older versions of the flutter tool.
+if (NOT DEFINED FLUTTER_TARGET_PLATFORM)
+  set(FLUTTER_TARGET_PLATFORM "windows-x64")
+endif()
+
 # === Flutter Library ===
 set(FLUTTER_LIBRARY "${EPHEMERAL_DIR}/flutter_windows.dll")
 
@@ -92,7 +97,7 @@ add_custom_command(
   COMMAND ${CMAKE_COMMAND} -E env
     ${FLUTTER_TOOL_ENVIRONMENT}
     "${FLUTTER_ROOT}/packages/flutter_tools/bin/tool_backend.bat"
-      windows-x64 $<CONFIG>
+      ${FLUTTER_TARGET_PLATFORM} $<CONFIG>
   VERBATIM
 )
 add_custom_target(flutter_assemble DEPENDS

--- a/lib/src/emoji_picker_internal_utils.dart
+++ b/lib/src/emoji_picker_internal_utils.dart
@@ -59,7 +59,7 @@ class EmojiPickerInternalUtils {
     });
   }
 
-  /// Returns list of recently used emoji from cache
+  /// Returns list of recently used emoji
   FutureOr<List<RecentEmoji>> getRecentEmojis() {
     if (_recentEmojis != null) {
       return _recentEmojis!.toList();

--- a/lib/src/emoji_picker_internal_utils.dart
+++ b/lib/src/emoji_picker_internal_utils.dart
@@ -1,8 +1,9 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:math';
 
 import 'package:emoji_picker_flutter/emoji_picker_flutter.dart';
-import 'package:flutter/foundation.dart';
+import 'package:flutter/foundation.dart' hide Category;
 import 'package:flutter/services.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -15,6 +16,10 @@ const initVal = 1;
 class EmojiPickerInternalUtils {
   // Establish communication with native
   static const _platform = MethodChannel('emoji_picker_flutter');
+
+  static final Map<Category, CategoryEmoji> _availableEmojis = {};
+
+  static List<RecentEmoji>? _recentEmojis;
 
   // Get available emoji for given category title
   Future<CategoryEmoji> _getAvailableEmojis(CategoryEmoji category) async {
@@ -30,24 +35,46 @@ class EmojiPickerInternalUtils {
   }
 
   /// Filters out emojis not supported on the platform
-  Future<List<CategoryEmoji>> filterUnsupported(
-      List<CategoryEmoji> data) async {
+  FutureOr<List<CategoryEmoji>> filterUnsupported(List<CategoryEmoji> data) {
     if (kIsWeb || !Platform.isAndroid) {
       return data;
     }
-    final futures = [for (final cat in data) _getAvailableEmojis(cat)];
-    return await Future.wait(futures);
+
+    if (data.every((e) => _availableEmojis.containsKey(e.category))) {
+      return data.map((e) => _availableEmojis[e.category]!).toList();
+    }
+
+    return Future(() async {
+      final futures = [
+        for (final cat
+            in data.where((e) => !_availableEmojis.containsKey(e.category)))
+          _getAvailableEmojis(cat)
+      ];
+
+      for (final cat in await Future.wait(futures)) {
+        _availableEmojis[cat.category] = cat;
+      }
+
+      return data.map((e) => _availableEmojis[e.category]!).toList();
+    });
   }
 
   /// Returns list of recently used emoji from cache
-  Future<List<RecentEmoji>> getRecentEmojis() async {
-    final prefs = await SharedPreferences.getInstance();
-    var emojiJson = prefs.getString('recent');
-    if (emojiJson == null) {
-      return [];
+  FutureOr<List<RecentEmoji>> getRecentEmojis() {
+    if (_recentEmojis != null) {
+      return _recentEmojis!.toList();
     }
-    var json = jsonDecode(emojiJson) as List<dynamic>;
-    return json.map<RecentEmoji>(RecentEmoji.fromJson).toList();
+
+    return Future(() async {
+      final prefs = await SharedPreferences.getInstance();
+      var emojiJson = prefs.getString('recent');
+      if (emojiJson == null) {
+        return [];
+      }
+      var json = jsonDecode(emojiJson) as List<dynamic>;
+      _recentEmojis = json.map<RecentEmoji>(RecentEmoji.fromJson).toList();
+      return _recentEmojis!;
+    });
   }
 
   /// Add an emoji to recently used list
@@ -57,7 +84,7 @@ class EmojiPickerInternalUtils {
     if (emoji.hasSkinTone) {
       emoji = removeSkinTone(emoji);
     }
-    var recentEmoji = await getRecentEmojis();
+    var recentEmoji = _recentEmojis ?? await getRecentEmojis();
     var recentEmojiIndex =
         recentEmoji.indexWhere((element) => element.emoji.emoji == emoji.emoji);
     if (recentEmojiIndex != -1) {
@@ -86,7 +113,7 @@ class EmojiPickerInternalUtils {
     if (emoji.hasSkinTone) {
       emoji = removeSkinTone(emoji);
     }
-    var recentEmoji = await getRecentEmojis();
+    var recentEmoji = _recentEmojis ?? await getRecentEmojis();
     var recentEmojiIndex =
         recentEmoji.indexWhere((element) => element.emoji.emoji == emoji.emoji);
     if (recentEmojiIndex != -1) {

--- a/lib/src/emoji_picker_utils.dart
+++ b/lib/src/emoji_picker_utils.dart
@@ -24,7 +24,7 @@ class EmojiPickerUtils {
   final List<Emoji> _allAvailableEmojiEntities = [];
   RegExp? _emojiRegExp;
 
-  /// Returns list of recently used emoji from cache
+  /// Returns list of recently used emoji
   FutureOr<List<RecentEmoji>> getRecentEmojis() {
     return EmojiPickerInternalUtils().getRecentEmojis();
   }
@@ -48,9 +48,9 @@ class EmojiPickerUtils {
 
       if (checkPlatformCompatibility) {
         final futureOrCategories =
-        emojiPickerInternalUtils.filterUnsupported(data);
+            emojiPickerInternalUtils.filterUnsupported(data);
 
-        if(futureOrCategories is List<CategoryEmoji>) {
+        if (futureOrCategories is List<CategoryEmoji>) {
           availableCategoryEmoji = futureOrCategories;
         } else {
           availableCategoryEmoji = await futureOrCategories;

--- a/lib/src/emoji_picker_utils.dart
+++ b/lib/src/emoji_picker_utils.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:math';
 
 import 'package:emoji_picker_flutter/emoji_picker_flutter.dart';
@@ -24,12 +25,12 @@ class EmojiPickerUtils {
   RegExp? _emojiRegExp;
 
   /// Returns list of recently used emoji from cache
-  Future<List<RecentEmoji>> getRecentEmojis() async {
+  FutureOr<List<RecentEmoji>> getRecentEmojis() {
     return EmojiPickerInternalUtils().getRecentEmojis();
   }
 
   /// Filters out emojis not supported on the platform
-  Future<List<CategoryEmoji>> filterUnsupported(List<CategoryEmoji> data) =>
+  FutureOr<List<CategoryEmoji>> filterUnsupported(List<CategoryEmoji> data) =>
       EmojiPickerInternalUtils().filterUnsupported(data);
 
   /// Search for related emoticons based on keywords
@@ -42,9 +43,21 @@ class EmojiPickerUtils {
 
       final data = [...emojiSet]
         ..removeWhere((e) => e.category == Category.RECENT);
-      final availableCategoryEmoji = checkPlatformCompatibility
-          ? await emojiPickerInternalUtils.filterUnsupported(data)
-          : data;
+
+      final List<CategoryEmoji> availableCategoryEmoji;
+
+      if (checkPlatformCompatibility) {
+        final futureOrCategories =
+        emojiPickerInternalUtils.filterUnsupported(data);
+
+        if(futureOrCategories is List<CategoryEmoji>) {
+          availableCategoryEmoji = futureOrCategories;
+        } else {
+          availableCategoryEmoji = await futureOrCategories;
+        }
+      } else {
+        availableCategoryEmoji = data;
+      }
 
       // Set all the emoji entities
       for (var emojis in availableCategoryEmoji) {

--- a/lib/src/search_view/search_view.dart
+++ b/lib/src/search_view/search_view.dart
@@ -41,11 +41,17 @@ class SearchViewState<T extends SearchView> extends State<T>
       // Auto focus textfield
       FocusScope.of(context).requestFocus(focusNode);
       // Load recent emojis initially
-      utils.getRecentEmojis().then(
-            (value) => setState(
-              () => _updateResults(value.map((e) => e.emoji).toList()),
-            ),
-          );
+      final futureOrRecent = utils.getRecentEmojis();
+
+      if (futureOrRecent is List<RecentEmoji>) {
+        _updateResults(futureOrRecent.map((e) => e.emoji).toList());
+      } else {
+        futureOrRecent.then(
+          (value) => setState(
+            () => _updateResults(value.map((e) => e.emoji).toList()),
+          ),
+        );
+      }
     });
     super.initState();
   }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -252,10 +252,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   mime:
     dependency: transitive
     description:
@@ -497,26 +497,26 @@ packages:
     dependency: "direct dev"
     description:
       name: test
-      sha256: "65e29d831719be0591f7b3b1a32a3cda258ec98c58c7b25f7b84241bc31215bb"
+      sha256: "75906bf273541b676716d1ca7627a17e4c4070a3a16272b7a3dc7da3b9f3f6b7"
       url: "https://pub.dev"
     source: hosted
-    version: "1.26.2"
+    version: "1.26.3"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.7"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "80bf5a02b60af04b09e14f6fe68b921aad119493e26e490deaca5993fef1b05a"
+      sha256: "0cc24b5ff94b38d2ae73e1eb43cc302b77964fbf67abad1e296025b78deb53d0"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.11"
+    version: "0.6.12"
   typed_data:
     dependency: transitive
     description:


### PR DESCRIPTION
## Description
This PR optimize the `EmojiPickerInternalUtils.filterUnsupported` and `EmojiPickerInternalUtils.getRecentEmojis` functions.
 
## Changes
* Save responses of the `EmojiPickerInternalUtils.filterUnsupported` and `EmojiPickerInternalUtils.getRecentEmojis` functions and reuse it.
* Make the `EmojiPickerInternalUtils.filterUnsupported` and `EmojiPickerInternalUtils.getRecentEmojis` functions to return `FutureOr`.
 
## Why this change?
* Reduce initialization time when `EmojiPicker` built second or subsequent times.

## Testing
* [x]   Verified that all existing functionality remains intact.
* [x]  Tested on relevant platforms, including web, to ensure compatibility.

## Checklist
* [x]  Code changes do not introduce breaking changes.
* [x]  Tested on different platforms, including web.
* [x]  Documentation/comments updated if necessary.