### PR TITLE
Fix memory leaks, race conditions, and regex recompilation

### DIFF
--- a/lib/src/emoji_picker.dart
+++ b/lib/src/emoji_picker.dart
@@ -222,8 +222,7 @@ class EmojiPickerState extends State<EmojiPicker> {
     if (oldWidget.textEditingController != widget.textEditingController) {
       oldWidget.textEditingController
           ?.removeListener(_scrollToCursorAfterTextChange);
-      widget.textEditingController
-          ?.addListener(_scrollToCursorAfterTextChange);
+      widget.textEditingController?.addListener(_scrollToCursorAfterTextChange);
     }
     _resetStateWhenOffstage();
     super.didUpdateWidget(oldWidget);

--- a/lib/src/emoji_picker.dart
+++ b/lib/src/emoji_picker.dart
@@ -218,6 +218,13 @@ class EmojiPickerState extends State<EmojiPicker> {
       oldWidget.controller?.removeListener(_onControllerChanged);
       widget.controller?.addListener(_onControllerChanged);
     }
+    // Handle text editing controller changes
+    if (oldWidget.textEditingController != widget.textEditingController) {
+      oldWidget.textEditingController
+          ?.removeListener(_scrollToCursorAfterTextChange);
+      widget.textEditingController
+          ?.addListener(_scrollToCursorAfterTextChange);
+    }
     _resetStateWhenOffstage();
     super.didUpdateWidget(oldWidget);
   }
@@ -521,6 +528,8 @@ class EmojiPickerState extends State<EmojiPicker> {
   @override
   void dispose() {
     widget.controller?.removeListener(_onControllerChanged);
+    widget.textEditingController
+        ?.removeListener(_scrollToCursorAfterTextChange);
     super.dispose();
   }
 }

--- a/lib/src/emoji_picker_internal_utils.dart
+++ b/lib/src/emoji_picker_internal_utils.dart
@@ -16,6 +16,8 @@ class EmojiPickerInternalUtils {
   // Establish communication with native
   static const _platform = MethodChannel('emoji_picker_flutter');
 
+  static final RegExp _skinToneRegExp = RegExp(SkinTone.values.join('|'));
+
   // Get available emoji for given category title
   Future<CategoryEmoji> _getAvailableEmojis(CategoryEmoji category) async {
     var available = (await _platform.invokeListMethod<bool>(
@@ -124,10 +126,7 @@ class EmojiPickerInternalUtils {
   /// Remove skin tone from given emoji
   Emoji removeSkinTone(Emoji emoji) {
     return emoji.copyWith(
-      emoji: emoji.emoji.replaceFirst(
-        RegExp(SkinTone.values.join('|')),
-        '',
-      ),
+      emoji: emoji.emoji.replaceFirst(_skinToneRegExp, ''),
     );
   }
 }

--- a/lib/src/emoji_picker_utils.dart
+++ b/lib/src/emoji_picker_utils.dart
@@ -20,6 +20,7 @@ class EmojiPickerUtils {
   EmojiPickerUtils._internal();
 
   static final EmojiPickerUtils _singleton = EmojiPickerUtils._internal();
+  static final RegExp _whitespaceRegExp = RegExp(r'\s+');
   final List<Emoji> _allAvailableEmojiEntities = [];
   RegExp? _emojiRegExp;
 
@@ -54,7 +55,7 @@ class EmojiPickerUtils {
 
     // Split the input string into a list of lowercase keywords
     final keywordSet = search
-        .split(RegExp(r'\s+'))
+        .split(_whitespaceRegExp)
         .where((e) => e.isNotEmpty)
         .map((e) => e.toLowerCase())
         .toSet();
@@ -182,6 +183,6 @@ class EmojiPickerUtils {
   /// Returns the emoji regex
   /// Based on https://unicode.org/reports/tr51/
   RegExp getEmojiRegex() {
-    return _emojiRegExp ?? RegExp(EmojiRegex, unicode: true);
+    return _emojiRegExp ??= RegExp(EmojiRegex, unicode: true);
   }
 }

--- a/lib/src/search_view/search_view.dart
+++ b/lib/src/search_view/search_view.dart
@@ -37,28 +37,33 @@ class SearchViewState<T extends SearchView> extends State<T>
 
   @override
   void initState() {
+    super.initState();
     WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
       // Auto focus textfield
       FocusScope.of(context).requestFocus(focusNode);
       // Load recent emojis initially
-      utils.getRecentEmojis().then(
-            (value) => setState(
-              () => _updateResults(value.map((e) => e.emoji).toList()),
-            ),
-          );
+      utils.getRecentEmojis().then((value) {
+        if (!mounted) return;
+        setState(() => _updateResults(value.map((e) => e.emoji).toList()));
+      });
     });
-    super.initState();
+  }
+
+  @override
+  void dispose() {
+    focusNode.dispose();
+    super.dispose();
   }
 
   /// On text input changed callback
   void onTextInputChanged(String text) {
     links.clear();
     results.clear();
-    utils.searchEmoji(text, widget.state.categoryEmoji).then(
-          (value) => setState(
-            () => _updateResults(value),
-          ),
-        );
+    utils.searchEmoji(text, widget.state.categoryEmoji).then((value) {
+      if (!mounted) return;
+      setState(() => _updateResults(value));
+    });
   }
 
   void _updateResults(List<Emoji> emojis) {

--- a/lib/src/skin_tones/skin_tone_overlay.dart
+++ b/lib/src/skin_tones/skin_tone_overlay.dart
@@ -143,7 +143,7 @@ mixin SkinToneOverlayStateMixin<T extends StatefulWidget> on State<T> {
 
   @override
   void dispose() {
-    _overlay?.dispose();
+    closeSkinToneOverlay();
     super.dispose();
   }
 }


### PR DESCRIPTION
## Summary

Investigation of the picker turned up several leaks, a setState-after-dispose race, and a few hot-path regex recompilations. This PR fixes them. No public API changes.

### Bugs fixed

- **`FocusNode` leak in `SearchViewState`** — `focusNode` was never disposed; it (and its keyboard listeners) leaked every time the search view was opened/closed. Added `dispose()` override.
- **`setState` after dispose in search** — `getRecentEmojis().then(...)` and `searchEmoji().then(...)` called `setState` without a `mounted` guard, crashing if the user dismissed the search before the future resolved. Added `mounted` checks (and moved `super.initState()` to the top of `initState`).
- **`TextEditingController` listener leak in `EmojiPickerState`** — the listener added in `initState` was never removed in `dispose`, and was not re-bound when the controller was swapped via `didUpdateWidget`. Both paths now handled.
- **`OverlayEntry.dispose()` assertion risk** — the skin-tone overlay mixin called `_overlay?.dispose()`, which asserts when the entry is still mounted. Switched to `closeSkinToneOverlay()` which removes first.

### Performance fixes

- **Emoji `RegExp` cache was dead code** — `getEmojiRegex()` returned `_emojiRegExp ?? RegExp(...)` but never assigned the field, so a new regex was compiled on every call (called per text change in `setEmojiTextStyle`). Changed to `??=`.
- **Skin-tone strip regex** — `RegExp(SkinTone.values.join('|'))` was rebuilt on every emoji selection. Hoisted to `static final`.
- **Search whitespace split regex** — `RegExp(r'\s+')` was rebuilt on every keystroke. Hoisted to `static final`.

### Files touched

- `lib/src/emoji_picker.dart`
- `lib/src/emoji_picker_internal_utils.dart`
- `lib/src/emoji_picker_utils.dart`
- `lib/src/search_view/search_view.dart`
- `lib/src/skin_tones/skin_tone_overlay.dart`

## Test plan

- [ ] `flutter analyze` clean
- [ ] `flutter test` passes (existing tests cover `removeSkinTone`, `setEmojiTextStyle`)
- [ ] Open and close the search view repeatedly — no leaked `FocusNode` warnings in DevTools
- [ ] Type into search, dismiss before async resolves — no "setState after dispose" exception
- [ ] Rebuild parent with a new `TextEditingController` — old controller has listener removed
- [ ] Open skin-tone overlay, then unmount the picker mid-overlay — no assertion thrown

https://claude.ai/code/session_0111AMC7Qk5NoRukS7kWumL2

---
_Generated by [Claude Code](https://claude.ai/code/session_0111AMC7Qk5NoRukS7kWumL2)_