### PR TITLE
Migrate Android plugin to Built-in Kotlin (conditional KGP apply)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 4.4.1
 
 - Bump minimum Flutter version to `3.41.8` (Dart `3.11.5`)
 - Fix memory leaks, race conditions, and regex recompilation
@@ -6,6 +6,7 @@
 - Add `rememberSkinTone` to `SkinToneConfig` to persist the last selected skin tone and re-apply it as the default in the grid, recents and search
 - Fix `applySkinTone` producing invalid double-modifier sequences when applied to an already toned glyph (existing tone is now stripped first)
 - Skin tone long-press picker now always applies the new tone to the base glyph
+- Migrate Android plugin to Flutter's Built-in Kotlin. The Kotlin Gradle Plugin (KGP) is now only applied on Android Gradle Plugin (AGP) versions prior to 9, preventing future build failures when Flutter removes its KGP compatibility shim while remaining backward compatible with older Flutter/AGP versions ([#260](https://github.com/Fintasys/emoji_picker_flutter/issues/260))
 
 ## 4.4.0
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -50,10 +50,19 @@ android {
     }
 }
 
-// kotlinOptions and kotlin-stdlib come from KGP; Built-in Kotlin supplies them.
+// Configure the Kotlin JVM target to match compileOptions (Java 17). It is not
+// inherited from compileOptions automatically, so it must be set on both paths.
+// Legacy KGP (<2.0) exposes kotlinOptions; Built-in Kotlin (AGP 9+, KGP 2.0+)
+// exposes the compilerOptions DSL instead.
 if (appliesLegacyKotlin) {
     android.kotlinOptions {
         jvmTarget = JavaVersion.VERSION_17.toString()
+    }
+} else {
+    kotlin {
+        compilerOptions {
+            jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
+        }
     }
 }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -23,16 +23,7 @@ rootProject.allprojects {
 
 apply plugin: 'com.android.library'
 
-// Built-in Kotlin migration.
-//
-// From Android Gradle Plugin (AGP) 9 onwards, Kotlin support is built in and
-// Flutter manages the Kotlin Gradle Plugin (KGP) centrally. Plugins that apply
-// KGP themselves fail to build against Built-in Kotlin. To remain compatible
-// with both older Flutter/AGP versions (which still require the plugin to apply
-// KGP to compile its Kotlin sources) and newer ones, only apply KGP when the
-// AGP in use predates Built-in Kotlin (AGP < 9).
-//
-// See https://docs.flutter.dev/release/breaking-changes/migrate-to-built-in-kotlin/for-plugin-authors
+// Built-in Kotlin: AGP 9+ provides Kotlin, so only apply KGP on older AGP.
 def agpMajorVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0].toInteger()
 def appliesLegacyKotlin = agpMajorVersion < 9
 if (appliesLegacyKotlin) {
@@ -59,9 +50,7 @@ android {
     }
 }
 
-// `kotlinOptions` is contributed by KGP, so it is only available when KGP is
-// applied. With Built-in Kotlin (AGP 9+) the Kotlin JVM target follows the Java
-// target configured in `compileOptions` above.
+// kotlinOptions and kotlin-stdlib come from KGP; Built-in Kotlin supplies them.
 if (appliesLegacyKotlin) {
     android.kotlinOptions {
         jvmTarget = JavaVersion.VERSION_17.toString()
@@ -69,8 +58,6 @@ if (appliesLegacyKotlin) {
 }
 
 dependencies {
-    // With Built-in Kotlin (AGP 9+) the Kotlin standard library is provided
-    // automatically, so only declare it explicitly on the legacy KGP path.
     if (appliesLegacyKotlin) {
         implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,7 +22,22 @@ rootProject.allprojects {
 }
 
 apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
+
+// Built-in Kotlin migration.
+//
+// From Android Gradle Plugin (AGP) 9 onwards, Kotlin support is built in and
+// Flutter manages the Kotlin Gradle Plugin (KGP) centrally. Plugins that apply
+// KGP themselves fail to build against Built-in Kotlin. To remain compatible
+// with both older Flutter/AGP versions (which still require the plugin to apply
+// KGP to compile its Kotlin sources) and newer ones, only apply KGP when the
+// AGP in use predates Built-in Kotlin (AGP < 9).
+//
+// See https://docs.flutter.dev/release/breaking-changes/migrate-to-built-in-kotlin/for-plugin-authors
+def agpMajorVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0].toInteger()
+def appliesLegacyKotlin = agpMajorVersion < 9
+if (appliesLegacyKotlin) {
+    apply plugin: 'kotlin-android'
+}
 
 android {
     if (project.android.hasProperty("namespace")) {
@@ -36,18 +51,27 @@ android {
         targetCompatibility JavaVersion.VERSION_17
     }
 
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_17.toString()
-    }
-
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
     }
     defaultConfig {
-        minSdkVersion 21   
+        minSdkVersion 21
+    }
+}
+
+// `kotlinOptions` is contributed by KGP, so it is only available when KGP is
+// applied. With Built-in Kotlin (AGP 9+) the Kotlin JVM target follows the Java
+// target configured in `compileOptions` above.
+if (appliesLegacyKotlin) {
+    android.kotlinOptions {
+        jvmTarget = JavaVersion.VERSION_17.toString()
     }
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    // With Built-in Kotlin (AGP 9+) the Kotlin standard library is provided
+    // automatically, so only declare it explicitly on the legacy KGP path.
+    if (appliesLegacyKotlin) {
+        implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: emoji_picker_flutter
 description: A Flutter package that provides an Emoji picker widget with 1500+ emojis in 8 categories.
-version: 4.4.0
+version: 4.4.1
 homepage: https://github.com/Fintasys/emoji_picker_flutter
 
 environment:


### PR DESCRIPTION
Only apply the Kotlin Gradle Plugin when the Android Gradle Plugin
predates Built-in Kotlin (AGP < 9). This prevents the future build
failure Flutter warns about once its KGP compatibility shim is removed,
while staying compatible with the plugin's current minimum Flutter
version.

Fixes #260

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01NSGyfYRC1ZdmSprDJ4ToSA