### PR TITLE
Add overflow-clip regression test for DefaultEmojiPickerView (#256)

### DIFF
--- a/test/emoji_picker_test.dart
+++ b/test/emoji_picker_test.dart
@@ -148,5 +148,58 @@ void main() {
       // Check if the category been passed to the 'onEmojiSelected' callback
       expect(_categorySelected, equals(Category.SMILEYS));
     });
+
+    testWidgets('Clips overflow when constrained tighter than natural height', (
+      WidgetTester tester,
+    ) async {
+      final _controller = TextEditingController();
+
+      // Constrain the picker far below the natural sum of the category bar
+      // and bottom action bar to force the inner Column to overflow (#256).
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Center(
+              child: SizedBox(
+                width: 300,
+                height: 30,
+                child: EmojiPicker(
+                  textEditingController: _controller,
+                  config: const Config(
+                    height: 30,
+                    categoryViewConfig: CategoryViewConfig(
+                      recentTabBehavior: RecentTabBehavior.NONE,
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      // A RenderFlex overflow is reported in debug mode; drain it so the test
+      // can assert the overflow is clipped rather than left painting stripes.
+      final exception = tester.takeException();
+      expect(
+        exception == null || exception.toString().contains('overflowed'),
+        isTrue,
+      );
+
+      // The inner view Column is wrapped in a ClipRect that clips the
+      // overflow (#256). Match that specific ClipRect (the one whose direct
+      // child is the Column) rather than the incidental ClipRects the grid
+      // and scroll views introduce.
+      expect(
+        find.descendant(
+          of: find.byType(EmojiContainer),
+          matching: find.byWidgetPredicate(
+            (widget) => widget is ClipRect && widget.child is Column,
+          ),
+        ),
+        findsOneWidget,
+      );
+    });
   });
 }


### PR DESCRIPTION
Salvages the widget test from #265.

The `ClipRect` production fix for #256 already landed on `master` via #259, which made #265's code change redundant (and conflicting). The one genuinely-new piece there was a regression test — this PR carries just that test over on top of current `master`.

The test constrains the picker well below its natural height and asserts the view `Column` is wrapped in a `ClipRect` (matched precisely via a widget predicate so it isn't affected by the incidental `ClipRect`s the grid/scroll views add).

All tests pass locally (`flutter test`).

Closes the coverage gap left by #265.