### PR TITLE
Cache supported and recent emojis to speed up EmojiPicker rebuilds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-- Cache platform-supported emojis and recently used emojis so a rebuilt `EmojiPicker` skips redundant native `getSupportedEmojis` calls and `SharedPreferences` reads. `EmojiPickerUtils.filterUnsupported` and `getRecentEmojis` now return `FutureOr` and resolve synchronously once cached. Support is cached per emoji glyph (not per resolved category), so results stay correct across locale switches and custom emoji sets, and the recent-emoji cache is kept in sync when emojis are added or cleared. (based on #252)
+- Cache platform-supported emojis and recently used emojis so a rebuilt `EmojiPicker` skips redundant native `getSupportedEmojis` calls and `SharedPreferences` reads, and resolves synchronously once cached. Support is cached per emoji glyph (not per resolved category), so results stay correct across locale switches and custom emoji sets, and the recent-emoji cache is kept in sync when emojis are added or cleared. The public `EmojiPickerUtils` API is unchanged (still returns `Future`). (based on #252)
 
 ## 4.5.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Cache platform-supported emojis and recently used emojis so a rebuilt `EmojiPicker` skips redundant native `getSupportedEmojis` calls and `SharedPreferences` reads. `EmojiPickerUtils.filterUnsupported` and `getRecentEmojis` now return `FutureOr` and resolve synchronously once cached. The recent-emoji cache is kept in sync when emojis are added or cleared. (based on #252)
+
 ## 4.5.0
 
 - Bump minimum Flutter version to `3.41.8` (Dart `3.11.5`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-- Cache platform-supported emojis and recently used emojis so a rebuilt `EmojiPicker` skips redundant native `getSupportedEmojis` calls and `SharedPreferences` reads. `EmojiPickerUtils.filterUnsupported` and `getRecentEmojis` now return `FutureOr` and resolve synchronously once cached. The recent-emoji cache is kept in sync when emojis are added or cleared. (based on #252)
+- Cache platform-supported emojis and recently used emojis so a rebuilt `EmojiPicker` skips redundant native `getSupportedEmojis` calls and `SharedPreferences` reads. `EmojiPickerUtils.filterUnsupported` and `getRecentEmojis` now return `FutureOr` and resolve synchronously once cached. Support is cached per emoji glyph (not per resolved category), so results stay correct across locale switches and custom emoji sets, and the recent-emoji cache is kept in sync when emojis are added or cleared. (based on #252)
 
 ## 4.5.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,7 @@
-## Unreleased
-
-- Cache platform-supported emojis and recently used emojis so a rebuilt `EmojiPicker` skips redundant native `getSupportedEmojis` calls and `SharedPreferences` reads, and resolves synchronously once cached. Support is cached per emoji glyph (not per resolved category), so results stay correct across locale switches and custom emoji sets, and the recent-emoji cache is kept in sync when emojis are added or cleared. The public `EmojiPickerUtils` API is unchanged (still returns `Future`). (based on #252)
-
 ## 4.5.0
 
 - Bump minimum Flutter version to `3.41.8` (Dart `3.11.5`)
+- Cache platform-supported emojis and recently used emojis so a rebuilt `EmojiPicker` skips redundant native `getSupportedEmojis` calls and `SharedPreferences` reads, and resolves synchronously once cached. Support is cached per emoji glyph (not per resolved category), so results stay correct across locale switches and custom emoji sets, and the recent-emoji cache is kept in sync when emojis are added or cleared. The public `EmojiPickerUtils` API is unchanged (still returns `Future`). (based on #252)
 - Fix memory leaks, race conditions, and regex recompilation
 - Clip picker overflow so it renders cleanly when constrained to a smaller height (#256)
 - Add `rememberSkinTone` to `SkinToneConfig` to persist the last selected skin tone and re-apply it as the default in the grid, recents and search

--- a/lib/src/emoji_picker.dart
+++ b/lib/src/emoji_picker.dart
@@ -437,8 +437,9 @@ class EmojiPickerState extends State<EmojiPicker> {
         widget.config.emojiSet?.call(widget.config.locale) ??
         getDefaultEmojiLocale(widget.config.locale);
     if (widget.config.checkPlatformCompatibility) {
-      final futureOrCategories =
-          _emojiPickerInternalUtils.filterUnsupported(data);
+      final futureOrCategories = _emojiPickerInternalUtils.filterUnsupported(
+        data,
+      );
       _categoryEmoji.addAll(
         futureOrCategories is List<CategoryEmoji>
             ? futureOrCategories

--- a/lib/src/emoji_picker.dart
+++ b/lib/src/emoji_picker.dart
@@ -426,18 +426,27 @@ class EmojiPickerState extends State<EmojiPicker> {
       RecentTabBehavior.RECENT,
       RecentTabBehavior.POPULAR,
     ].contains(widget.config.categoryViewConfig.recentTabBehavior)) {
-      _recentEmoji = await _emojiPickerInternalUtils.getRecentEmojis();
+      final futureOrRecent = _emojiPickerInternalUtils.getRecentEmojis();
+      _recentEmoji = futureOrRecent is List<RecentEmoji>
+          ? futureOrRecent
+          : await futureOrRecent;
       final recentEmojiMap = _recentEmoji.map((e) => e.emoji).toList();
       _categoryEmoji.add(CategoryEmoji(Category.RECENT, recentEmojiMap));
     }
     final data =
         widget.config.emojiSet?.call(widget.config.locale) ??
         getDefaultEmojiLocale(widget.config.locale);
-    _categoryEmoji.addAll(
-      widget.config.checkPlatformCompatibility
-          ? await _emojiPickerInternalUtils.filterUnsupported(data)
-          : data,
-    );
+    if (widget.config.checkPlatformCompatibility) {
+      final futureOrCategories =
+          _emojiPickerInternalUtils.filterUnsupported(data);
+      _categoryEmoji.addAll(
+        futureOrCategories is List<CategoryEmoji>
+            ? futureOrCategories
+            : await futureOrCategories,
+      );
+    } else {
+      _categoryEmoji.addAll(data);
+    }
     _state = EmojiViewState(
       _categoryEmoji,
       _onEmojiSelected,

--- a/lib/src/emoji_picker_internal_utils.dart
+++ b/lib/src/emoji_picker_internal_utils.dart
@@ -49,9 +49,7 @@ class EmojiPickerInternalUtils {
   CategoryEmoji _applySupport(CategoryEmoji category) {
     final support = _emojiSupport[category.category];
     return category.copyWith(
-      emoji: category.emoji
-          .where((e) => support?[e.emoji] ?? false)
-          .toList(),
+      emoji: category.emoji.where((e) => support?[e.emoji] ?? false).toList(),
     );
   }
 
@@ -109,8 +107,9 @@ class EmojiPickerInternalUtils {
         return _recentEmojis = [];
       }
       var json = jsonDecode(emojiJson) as List<dynamic>;
-      return _recentEmojis =
-          json.map<RecentEmoji>(RecentEmoji.fromJson).toList();
+      return _recentEmojis = json
+          .map<RecentEmoji>(RecentEmoji.fromJson)
+          .toList();
     });
   }
 

--- a/lib/src/emoji_picker_internal_utils.dart
+++ b/lib/src/emoji_picker_internal_utils.dart
@@ -1,8 +1,9 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:math';
 
 import 'package:emoji_picker_flutter/emoji_picker_flutter.dart';
-import 'package:flutter/foundation.dart';
+import 'package:flutter/foundation.dart' hide Category;
 import 'package:flutter/services.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -17,6 +18,15 @@ class EmojiPickerInternalUtils {
   static const _platform = MethodChannel('emoji_picker_flutter');
 
   static final RegExp _skinToneRegExp = RegExp(SkinTone.values.join('|'));
+
+  /// Caches the platform-supported emojis per [Category] so that
+  /// [filterUnsupported] only queries the native side once per category.
+  static final Map<Category, CategoryEmoji> _availableEmojis = {};
+
+  /// Caches the recently used emojis so that [getRecentEmojis] avoids
+  /// re-reading [SharedPreferences] on subsequent calls. Kept in sync by the
+  /// add/clear methods below.
+  static List<RecentEmoji>? _recentEmojis;
 
   // Get available emoji for given category title
   Future<CategoryEmoji> _getAvailableEmojis(CategoryEmoji category) async {
@@ -34,25 +44,53 @@ class EmojiPickerInternalUtils {
   }
 
   /// Filters out emojis not supported on the platform
-  Future<List<CategoryEmoji>> filterUnsupported(
-    List<CategoryEmoji> data,
-  ) async {
+  ///
+  /// Returns synchronously when every requested category is already cached,
+  /// so a rebuilt [EmojiPicker] does not have to hit the native side again.
+  FutureOr<List<CategoryEmoji>> filterUnsupported(List<CategoryEmoji> data) {
     if (kIsWeb || !Platform.isAndroid) {
       return data;
     }
-    final futures = [for (final cat in data) _getAvailableEmojis(cat)];
-    return await Future.wait(futures);
+
+    if (data.every((e) => _availableEmojis.containsKey(e.category))) {
+      return data.map((e) => _availableEmojis[e.category]!).toList();
+    }
+
+    return Future(() async {
+      final futures = [
+        for (final cat
+            in data.where((e) => !_availableEmojis.containsKey(e.category)))
+          _getAvailableEmojis(cat),
+      ];
+
+      for (final cat in await Future.wait(futures)) {
+        _availableEmojis[cat.category] = cat;
+      }
+
+      return data.map((e) => _availableEmojis[e.category]!).toList();
+    });
   }
 
   /// Returns list of recently used emoji from cache
-  Future<List<RecentEmoji>> getRecentEmojis() async {
-    final prefs = await SharedPreferences.getInstance();
-    var emojiJson = prefs.getString('recent');
-    if (emojiJson == null) {
-      return [];
+  ///
+  /// Reads from [SharedPreferences] on the first call and reuses the cached
+  /// result afterwards. The cache is kept in sync by [addEmojiToRecentlyUsed],
+  /// [addEmojiToPopularUsed] and [clearRecentEmojisInLocalStorage].
+  FutureOr<List<RecentEmoji>> getRecentEmojis() {
+    if (_recentEmojis != null) {
+      return _recentEmojis!.toList();
     }
-    var json = jsonDecode(emojiJson) as List<dynamic>;
-    return json.map<RecentEmoji>(RecentEmoji.fromJson).toList();
+
+    return Future(() async {
+      final prefs = await SharedPreferences.getInstance();
+      var emojiJson = prefs.getString('recent');
+      if (emojiJson == null) {
+        return _recentEmojis = [];
+      }
+      var json = jsonDecode(emojiJson) as List<dynamic>;
+      return _recentEmojis =
+          json.map<RecentEmoji>(RecentEmoji.fromJson).toList();
+    });
   }
 
   /// Add an emoji to recently used list
@@ -86,7 +124,7 @@ class EmojiPickerInternalUtils {
     final prefs = await SharedPreferences.getInstance();
     prefs.setString('recent', jsonEncode(recentEmoji));
 
-    return recentEmoji;
+    return _recentEmojis = recentEmoji;
   }
 
   /// Add an emoji to popular used list or increase its counter
@@ -127,13 +165,14 @@ class EmojiPickerInternalUtils {
     final prefs = await SharedPreferences.getInstance();
     prefs.setString('recent', jsonEncode(recentEmoji));
 
-    return recentEmoji;
+    return _recentEmojis = recentEmoji;
   }
 
   /// Clears the list of recent emojis in local storage
   Future<void> clearRecentEmojisInLocalStorage() async {
     final prefs = await SharedPreferences.getInstance();
     prefs.setString('recent', jsonEncode([]));
+    _recentEmojis = [];
   }
 
   /// Returns the last remembered skin tone modifier, or `null` if none stored

--- a/lib/src/emoji_picker_internal_utils.dart
+++ b/lib/src/emoji_picker_internal_utils.dart
@@ -19,55 +19,76 @@ class EmojiPickerInternalUtils {
 
   static final RegExp _skinToneRegExp = RegExp(SkinTone.values.join('|'));
 
-  /// Caches the platform-supported emojis per [Category] so that
-  /// [filterUnsupported] only queries the native side once per category.
-  static final Map<Category, CategoryEmoji> _availableEmojis = {};
+  /// Caches, per [Category], whether each emoji glyph is supported on the
+  /// platform. Keyed by the emoji string (not the [CategoryEmoji]) so the
+  /// cache stays correct across locales and custom emoji sets, which change
+  /// an emoji's name/keywords but never the glyph or its platform support.
+  static final Map<Category, Map<String, bool>> _emojiSupport = {};
 
   /// Caches the recently used emojis so that [getRecentEmojis] avoids
   /// re-reading [SharedPreferences] on subsequent calls. Kept in sync by the
   /// add/clear methods below.
   static List<RecentEmoji>? _recentEmojis;
 
-  // Get available emoji for given category title
-  Future<CategoryEmoji> _getAvailableEmojis(CategoryEmoji category) async {
-    var available = (await _platform.invokeListMethod<bool>(
+  // Query the native side for which of the given glyphs are supported and
+  // merge the result into the per-category support cache.
+  Future<void> _cacheSupport(CategoryEmoji category, List<Emoji> query) async {
+    final available = (await _platform.invokeListMethod<bool>(
       'getSupportedEmojis',
-      {'source': category.emoji.map((e) => e.emoji).toList(growable: false)},
+      {'source': query.map((e) => e.emoji).toList(growable: false)},
     ))!;
 
+    final support = _emojiSupport.putIfAbsent(category.category, () => {});
+    for (var i = 0; i < query.length; i++) {
+      support[query[i].emoji] = available[i];
+    }
+  }
+
+  // Filter a category down to the glyphs known to be supported. Every glyph is
+  // expected to be present in the cache by the time this is called.
+  CategoryEmoji _applySupport(CategoryEmoji category) {
+    final support = _emojiSupport[category.category];
     return category.copyWith(
-      emoji: [
-        for (int i = 0; i < available.length; i++)
-          if (available[i]) category.emoji[i],
-      ],
+      emoji: category.emoji
+          .where((e) => support?[e.emoji] ?? false)
+          .toList(),
     );
   }
 
   /// Filters out emojis not supported on the platform
   ///
-  /// Returns synchronously when every requested category is already cached,
-  /// so a rebuilt [EmojiPicker] does not have to hit the native side again.
+  /// Returns synchronously when the support of every requested glyph is
+  /// already cached, so a rebuilt [EmojiPicker] does not have to hit the
+  /// native side again. Glyphs whose support is not yet known (e.g. after a
+  /// locale switch that introduces new glyphs, or a custom emoji set) are
+  /// queried and merged into the cache.
   FutureOr<List<CategoryEmoji>> filterUnsupported(List<CategoryEmoji> data) {
     if (kIsWeb || !Platform.isAndroid) {
       return data;
     }
 
-    if (data.every((e) => _availableEmojis.containsKey(e.category))) {
-      return data.map((e) => _availableEmojis[e.category]!).toList();
+    // Collect, per category, the glyphs whose support is not yet cached.
+    final pending = <CategoryEmoji, List<Emoji>>{};
+    for (final cat in data) {
+      final support = _emojiSupport[cat.category];
+      final unknown = support == null
+          ? cat.emoji
+          : cat.emoji.where((e) => !support.containsKey(e.emoji)).toList();
+      if (unknown.isNotEmpty) {
+        pending[cat] = unknown;
+      }
+    }
+
+    if (pending.isEmpty) {
+      return [for (final cat in data) _applySupport(cat)];
     }
 
     return Future(() async {
-      final futures = [
-        for (final cat
-            in data.where((e) => !_availableEmojis.containsKey(e.category)))
-          _getAvailableEmojis(cat),
-      ];
-
-      for (final cat in await Future.wait(futures)) {
-        _availableEmojis[cat.category] = cat;
-      }
-
-      return data.map((e) => _availableEmojis[e.category]!).toList();
+      await Future.wait([
+        for (final entry in pending.entries)
+          _cacheSupport(entry.key, entry.value),
+      ]);
+      return [for (final cat in data) _applySupport(cat)];
     });
   }
 
@@ -194,5 +215,14 @@ class EmojiPickerInternalUtils {
   /// Remove skin tone from given emoji
   Emoji removeSkinTone(Emoji emoji) {
     return emoji.copyWith(emoji: emoji.emoji.replaceFirst(_skinToneRegExp, ''));
+  }
+
+  /// Clears the in-memory caches. The caches are `static`, so they otherwise
+  /// persist for the lifetime of the isolate and can leak state between test
+  /// cases. Call this in `setUp`/`tearDown` to keep tests isolated.
+  @visibleForTesting
+  static void resetCaches() {
+    _emojiSupport.clear();
+    _recentEmojis = null;
   }
 }

--- a/lib/src/emoji_picker_utils.dart
+++ b/lib/src/emoji_picker_utils.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:math';
 
 import 'package:emoji_picker_flutter/emoji_picker_flutter.dart';
@@ -25,12 +26,11 @@ class EmojiPickerUtils {
   RegExp? _emojiRegExp;
 
   /// Returns list of recently used emoji from cache
-  Future<List<RecentEmoji>> getRecentEmojis() async {
-    return EmojiPickerInternalUtils().getRecentEmojis();
-  }
+  FutureOr<List<RecentEmoji>> getRecentEmojis() =>
+      EmojiPickerInternalUtils().getRecentEmojis();
 
   /// Filters out emojis not supported on the platform
-  Future<List<CategoryEmoji>> filterUnsupported(List<CategoryEmoji> data) =>
+  FutureOr<List<CategoryEmoji>> filterUnsupported(List<CategoryEmoji> data) =>
       EmojiPickerInternalUtils().filterUnsupported(data);
 
   /// Search for related emoticons based on keywords

--- a/lib/src/emoji_picker_utils.dart
+++ b/lib/src/emoji_picker_utils.dart
@@ -1,4 +1,3 @@
-import 'dart:async';
 import 'dart:math';
 
 import 'package:emoji_picker_flutter/emoji_picker_flutter.dart';
@@ -26,12 +25,12 @@ class EmojiPickerUtils {
   RegExp? _emojiRegExp;
 
   /// Returns list of recently used emoji from cache
-  FutureOr<List<RecentEmoji>> getRecentEmojis() =>
-      EmojiPickerInternalUtils().getRecentEmojis();
+  Future<List<RecentEmoji>> getRecentEmojis() =>
+      Future.value(EmojiPickerInternalUtils().getRecentEmojis());
 
   /// Filters out emojis not supported on the platform
-  FutureOr<List<CategoryEmoji>> filterUnsupported(List<CategoryEmoji> data) =>
-      EmojiPickerInternalUtils().filterUnsupported(data);
+  Future<List<CategoryEmoji>> filterUnsupported(List<CategoryEmoji> data) =>
+      Future.value(EmojiPickerInternalUtils().filterUnsupported(data));
 
   /// Search for related emoticons based on keywords
   Future<List<Emoji>> searchEmoji(

--- a/lib/src/search_view/search_view.dart
+++ b/lib/src/search_view/search_view.dart
@@ -43,10 +43,17 @@ class SearchViewState<T extends SearchView> extends State<T>
       // Auto focus textfield
       FocusScope.of(context).requestFocus(focusNode);
       // Load recent emojis initially
-      utils.getRecentEmojis().then((value) {
-        if (!mounted) return;
-        setState(() => _updateResults(value.map((e) => e.emoji).toList()));
-      });
+      final futureOrRecent = utils.getRecentEmojis();
+      if (futureOrRecent is List<RecentEmoji>) {
+        setState(
+          () => _updateResults(futureOrRecent.map((e) => e.emoji).toList()),
+        );
+      } else {
+        futureOrRecent.then((value) {
+          if (!mounted) return;
+          setState(() => _updateResults(value.map((e) => e.emoji).toList()));
+        });
+      }
     });
   }
 

--- a/lib/src/search_view/search_view.dart
+++ b/lib/src/search_view/search_view.dart
@@ -1,4 +1,5 @@
 import 'package:emoji_picker_flutter/emoji_picker_flutter.dart';
+import 'package:emoji_picker_flutter/src/emoji_picker_internal_utils.dart';
 import 'package:flutter/material.dart';
 
 /// Template class for custom implementation
@@ -24,6 +25,10 @@ class SearchViewState<T extends SearchView> extends State<T>
   /// Emoji picker utils
   final utils = EmojiPickerUtils();
 
+  /// Internal utils, used for the cache-backed synchronous fast-path when
+  /// loading recent emojis (the public [utils] returns a `Future`).
+  final _internalUtils = EmojiPickerInternalUtils();
+
   /// Focus node for textfield
   final focusNode = FocusNode();
 
@@ -43,7 +48,7 @@ class SearchViewState<T extends SearchView> extends State<T>
       // Auto focus textfield
       FocusScope.of(context).requestFocus(focusNode);
       // Load recent emojis initially
-      final futureOrRecent = utils.getRecentEmojis();
+      final futureOrRecent = _internalUtils.getRecentEmojis();
       if (futureOrRecent is List<RecentEmoji>) {
         setState(
           () => _updateResults(futureOrRecent.map((e) => e.emoji).toList()),

--- a/test/emoji_picker_test.dart
+++ b/test/emoji_picker_test.dart
@@ -1,4 +1,5 @@
 import 'package:emoji_picker_flutter/emoji_picker_flutter.dart';
+import 'package:emoji_picker_flutter/src/emoji_picker_internal_utils.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -10,6 +11,9 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   group('EmojiPicker Tests', () {
+    // Caches are static and would otherwise leak between test cases.
+    setUp(EmojiPickerInternalUtils.resetCaches);
+
     testWidgets('Should allow user to select an emoji', (
       WidgetTester tester,
     ) async {


### PR DESCRIPTION
## Description

Revives the still-relevant part of #252: caching for `EmojiPickerInternalUtils.filterUnsupported` and `getRecentEmojis`, so building an `EmojiPicker` a second (or later) time skips redundant work.

The unrelated churn from #252 (lockfile bumps, `.gitignore`, Windows scaffolding) is intentionally left out. The recent-emoji cache invalidation bug in the original PR is fixed here, and the support cache is keyed per glyph so it stays correct across locales and custom emoji sets.

## Changes

- **`filterUnsupported`** caches platform support **per emoji glyph** per `Category` (`Map<Category, Map<String, bool>>`) and returns synchronously when every requested glyph's support is already known — no repeat calls to the native `getSupportedEmojis` channel. Because glyphs (and their platform support) are stable across locales/custom sets while only names/keywords change, results stay correct after a locale switch; glyphs never queried before are fetched and merged on demand.
- **`getRecentEmojis`** caches the decoded recent list to avoid re-reading `SharedPreferences`. The cache is kept in sync by `addEmojiToRecentlyUsed`, `addEmojiToPopularUsed`, and `clearRecentEmojisInLocalStorage`, so it never returns stale data (this was broken in #252).
- Internal call sites (`emoji_picker.dart`, `search_view.dart`) take a synchronous fast-path via `EmojiPickerInternalUtils` (which returns `FutureOr`) when cached data is available.
- Added `EmojiPickerInternalUtils.resetCaches()` (`@visibleForTesting`) and wired it into the test `setUp` so the static caches don't leak between test cases.

## Non-breaking

The **public** `EmojiPickerUtils.filterUnsupported` / `getRecentEmojis` still return `Future` — the exported API is unchanged, so this is a **minor** release, no major bump. The `FutureOr` fast-path lives only on the non-exported `EmojiPickerInternalUtils`.

## Why

- Faster initialization on the 2nd+ build of an `EmojiPicker` (avoids native round-trips + disk reads).
- Avoids an event-loop turn / flash of empty content when cached data is available synchronously.

## Testing

- `flutter analyze` — no issues
- `flutter test` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)