### PR TITLE
Fix recent-emoji list leaking into UI on unrelated parent rebuild

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 4.5.0
 
 - Bump minimum Flutter version to `3.41.8` (Dart `3.11.5`)
+- Fix recent-emoji list changing on an unrelated parent rebuild. A recent update with `refresh: false` (e.g. selecting an emoji while the `RECENT` tab is visible) no longer mutates the displayed category data, so the list stays stable until the next explicit refresh instead of jumping on a stray rebuild ([#238](https://github.com/Fintasys/emoji_picker_flutter/pull/238))
 - Fix memory leaks, race conditions, and regex recompilation
 - Clip picker overflow so it renders cleanly when constrained to a smaller height (#256)
 - Add `rememberSkinTone` to `SkinToneConfig` to persist the last selected skin tone and re-apply it as the default in the grid, recents and search

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -55,7 +55,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "4.4.0"
+    version: "4.5.0"
   fake_async:
     dependency: transitive
     description:

--- a/lib/src/emoji_picker.dart
+++ b/lib/src/emoji_picker.dart
@@ -194,6 +194,16 @@ class EmojiPickerState extends State<EmojiPicker> {
     bool refresh = false,
   }) {
     _recentEmoji = recentEmoji;
+    // Only mutate the displayed category data when we actually intend to
+    // refresh the UI. `_categoryEmoji` is shared by reference with `_state`,
+    // so mutating it here without a `setState()` would still surface the new
+    // recent list on the next unrelated rebuild triggered by a parent widget
+    // (e.g. the RECENT tab re-ordering under the user). The persisted store is
+    // already updated by the caller, so the change is not lost - it simply
+    // becomes visible on the next explicit refresh instead of leaking early.
+    if (!refresh) {
+      return;
+    }
     final recentTabIndex = _categoryEmoji.indexWhere(
       (element) => element.category == Category.RECENT,
     );
@@ -201,7 +211,7 @@ class EmojiPickerState extends State<EmojiPicker> {
       _categoryEmoji[recentTabIndex] = _categoryEmoji[recentTabIndex].copyWith(
         emoji: _recentEmoji.map((e) => e.emoji).toList(),
       );
-      if (mounted && refresh) {
+      if (mounted) {
         setState(() {});
       }
     }

--- a/test/recent_emoji_state_test.dart
+++ b/test/recent_emoji_state_test.dart
@@ -1,0 +1,146 @@
+import 'package:emoji_picker_flutter/emoji_picker_flutter.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Test harness that lets us trigger a rebuild of [EmojiPicker] from its
+/// parent, mimicking an unrelated `setState()` higher up in the widget tree.
+class _RebuildHarness extends StatefulWidget {
+  const _RebuildHarness({
+    super.key,
+    required this.pickerKey,
+    required this.config,
+  });
+
+  final GlobalKey<EmojiPickerState> pickerKey;
+  final Config config;
+
+  @override
+  State<_RebuildHarness> createState() => _RebuildHarnessState();
+}
+
+class _RebuildHarnessState extends State<_RebuildHarness> {
+  int _rebuildCounter = 0;
+
+  /// Force the parent to rebuild without touching the picker's own state.
+  void forceRebuild() => setState(() => _rebuildCounter++);
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      home: Scaffold(
+        // Reference the counter so the framework actually rebuilds the subtree.
+        body: Column(
+          children: [
+            Text('rebuilds: $_rebuildCounter'),
+            Expanded(
+              child: EmojiPicker(
+                key: widget.pickerKey,
+                config: widget.config,
+                onEmojiSelected: (_, __) {},
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const config = Config(
+    height: 400,
+    categoryViewConfig: CategoryViewConfig(
+      initCategory: Category.RECENT,
+      recentTabBehavior: RecentTabBehavior.RECENT,
+    ),
+  );
+
+  const emoji = Emoji('😀', 'grinning face');
+
+  setUp(() {
+    // Start every test with an empty recent-emoji store.
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  testWidgets(
+    'A recent update with refresh:false must not leak into the UI on an '
+    'unrelated parent rebuild',
+    (tester) async {
+      final pickerKey = GlobalKey<EmojiPickerState>();
+      final harnessKey = GlobalKey<_RebuildHarnessState>();
+
+      await tester.pumpWidget(
+        _RebuildHarness(key: harnessKey, pickerKey: pickerKey, config: config),
+      );
+      await tester.pumpAndSettle();
+
+      // Recent tab starts empty.
+      expect(find.text('No Recents'), findsOneWidget);
+      expect(find.text(emoji.emoji), findsNothing);
+
+      // Persist a recent emoji through the public API. This calls
+      // `updateRecentEmoji(..., refresh: false)` under the hood - the same
+      // path taken when an emoji is tapped while the RECENT tab is visible.
+      await EmojiPickerUtils().addEmojiToRecentlyUsed(
+        key: pickerKey,
+        emoji: emoji,
+        config: config,
+      );
+      await tester.pumpAndSettle();
+
+      // refresh:false means the visible list must NOT change yet.
+      expect(
+        find.text('No Recents'),
+        findsOneWidget,
+        reason: 'refresh:false should not update the UI immediately',
+      );
+      expect(find.text(emoji.emoji), findsNothing);
+
+      // Now an unrelated part of the app rebuilds the widget tree.
+      harnessKey.currentState!.forceRebuild();
+      await tester.pumpAndSettle();
+
+      // The recent list must STILL be unchanged: a refresh:false update is not
+      // allowed to surface on a stray rebuild triggered from a parent widget.
+      expect(
+        find.text('No Recents'),
+        findsOneWidget,
+        reason: 'a refresh:false update must not leak in on a parent rebuild',
+      );
+      expect(find.text(emoji.emoji), findsNothing);
+    },
+  );
+
+  testWidgets('A recent update with refresh:true updates the UI immediately', (
+    tester,
+  ) async {
+    final pickerKey = GlobalKey<EmojiPickerState>();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: EmojiPicker(
+            key: pickerKey,
+            config: config,
+            onEmojiSelected: (_, __) {},
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('No Recents'), findsOneWidget);
+
+    // An explicit refresh must render the new recent emoji right away.
+    pickerKey.currentState!.updateRecentEmoji([
+      RecentEmoji(emoji, 1),
+    ], refresh: true);
+    await tester.pumpAndSettle();
+
+    expect(find.text('No Recents'), findsNothing);
+    expect(find.text(emoji.emoji), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Problem

Reported in #238: selecting an emoji while the **RECENT** tab is visible could make the recent list suddenly re-order/jump later, in reaction to an unrelated rebuild triggered by a parent widget.

## Root cause

`EmojiPickerState.updateRecentEmoji(refresh: false)` only gated the `setState()` call with the `refresh` flag — it *always* mutated `_categoryEmoji` regardless:

```dart
_recentEmoji = recentEmoji;
_categoryEmoji[recentTabIndex] = _categoryEmoji[recentTabIndex].copyWith(
  emoji: _recentEmoji.map((e) => e.emoji).toList(),
);
if (mounted && refresh) {
  setState(() {});
}
```

`_categoryEmoji` is the **same list instance** held by reference in `EmojiViewState` (`_state = EmojiViewState(_categoryEmoji, ...)`), and `DefaultEmojiPickerView` rebuilds the recent grid straight from it on every `build()`. So on the RECENT tab, tapping an emoji reorders the data silently (no `setState`, no visible change) — but the next stray rebuild from a parent widget paints that already-mutated data, and the recent list jumps.

This is exactly the inconsistency described in the #238 discussion: *"it updates the list in the state, but doesn't update the UI"*.

## Fix

Skip the displayed-category mutation entirely when `refresh` is `false`. The persisted store is already updated by the caller (`addEmojiToRecentlyUsed` / `addEmojiToPopularUsed` write before this call), so nothing is lost — the change simply becomes visible on the next explicit refresh instead of leaking in early.

## Test

Adds `test/recent_emoji_state_test.dart`:

- **refresh:false must not leak** — persists a recent emoji via the public `EmojiPickerUtils.addEmojiToRecentlyUsed` API (which calls `updateRecentEmoji(refresh: false)`), then forces an unrelated parent rebuild and asserts the recent tab is unchanged. Fails on the old code, passes with the fix.
- **refresh:true updates immediately** — asserts an explicit refresh still renders the new recent emoji right away.

Full suite (15 tests) passes; `flutter analyze` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)